### PR TITLE
feat | sprint2 | FRB-143 | 센서 임계치·허용치 반영 및 자동제어 메시지 로직 추가 | 윤다인

### DIFF
--- a/src/main/java/com/factoreal/backend/consumer/kafka/KafkaConsumer.java
+++ b/src/main/java/com/factoreal/backend/consumer/kafka/KafkaConsumer.java
@@ -26,6 +26,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import com.factoreal.backend.service.SensorService;
 import com.factoreal.backend.entity.Sensor;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 
 import java.time.Instant;
 import java.time.LocalDateTime;

--- a/src/main/java/com/factoreal/backend/controller/SensorController.java
+++ b/src/main/java/com/factoreal/backend/controller/SensorController.java
@@ -46,7 +46,7 @@ public class SensorController {
 
     // DB Sensor Table 업데이트 ( FE -> BE 센서ID 매핑해서 센서목적, 위치, 임계치 업데이트 )
     @PostMapping("/{sensorId}")
-    @Operation(summary = "센서 정보 업데이트", description = "센서ID 매핑해서 센서목적, 위치, 임계치 업데이트 (FE -> BE) ")
+    @Operation(summary = "센서 정보 업데이트", description = "센서ID 매핑해서 임계치(sensorThres)와 허용치(allowVal) 업데이트 (FE -> BE) ")
     public ResponseEntity<Void> update(
             @PathVariable("sensorId") String sensorId,
             @RequestBody SensorUpdateDto dto) {

--- a/src/main/java/com/factoreal/backend/dto/SensorDto.java
+++ b/src/main/java/com/factoreal/backend/dto/SensorDto.java
@@ -13,10 +13,8 @@ public class SensorDto { // BE -> FE 용 DTO
     private String sensorType; // 센서종류
     private String zoneId; // zoneId 저장
     private String equipId;
-
-    // 내가 수정한 부분.... 여기랑 리턴문
-    private Double sensorThres;
-    private Double sensorAllowVal;
+    private Double sensorThres; // 임계치
+    private Double allowVal;     // 허용치
 
     public static SensorDto fromEntity(Sensor sensor) {
         if (sensor == null) return null;
@@ -27,7 +25,7 @@ public class SensorDto { // BE -> FE 용 DTO
                 .zoneId(sensor.getZone().getZoneId())
                 .equipId(sensor.getEquip().getEquipId())
                 .sensorThres(sensor.getSensorThres())
-                .sensorAllowVal(sensor.getAllowVal())
+                .allowVal(sensor.getAllowVal())
                 .build();
     }
 }

--- a/src/main/java/com/factoreal/backend/dto/SensorUpdateDto.java
+++ b/src/main/java/com/factoreal/backend/dto/SensorUpdateDto.java
@@ -8,8 +8,8 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class SensorUpdateDto {
-    private String sensorPurpose;  // 센서목적
-    private String location;       // 위치
+    // private String sensorPurpose;  // 센서목적
+    // private String location;       // 위치
     private Double sensorThres;      // 임계치
     private Double allowVal;       // 허용치(오차범위)
 

--- a/src/main/java/com/factoreal/backend/dto/SensorUpdateDto.java
+++ b/src/main/java/com/factoreal/backend/dto/SensorUpdateDto.java
@@ -10,7 +10,8 @@ import lombok.Setter;
 public class SensorUpdateDto {
     private String sensorPurpose;  // 센서목적
     private String location;       // 위치
-    private Integer threshold;     // 임계치
+    private Double sensorThres;      // 임계치
+    private Double allowVal;       // 허용치(오차범위)
 
     public SensorUpdateDto() {}
 }

--- a/src/main/java/com/factoreal/backend/dto/SystemLogDto.java
+++ b/src/main/java/com/factoreal/backend/dto/SystemLogDto.java
@@ -14,6 +14,7 @@ public class SystemLogDto {
     private String zoneName;
     private String sensorType;
     private int dangerLevel; // 위험도 수준
+    private double value; // 측정값
     private String timestamp; // 로그 생성 시간
 }
 /**
@@ -22,6 +23,7 @@ public class SystemLogDto {
   "zoneName": "포장 구역 B",
   "sensorType": "temp",
   "dangerLevel": 2,
+  "value": 25.5,
   "timestamp": "2025-05-09T15:22:31"
 }
  */

--- a/src/main/java/com/factoreal/backend/service/SensorService.java
+++ b/src/main/java/com/factoreal/backend/service/SensorService.java
@@ -68,6 +68,16 @@ public class SensorService {
         Sensor sensor = repo.findBySensorId(sensorId)
             .orElseThrow(() -> new ResponseStatusException(
                 HttpStatus.NOT_FOUND, "존재하지 않는 센서 ID: " + sensorId));
+        sensor.setSensorThres(dto.getSensorThres());
+        sensor.setAllowVal(dto.getAllowVal());
         repo.save(sensor);
+    }
+
+    /** 이전에 repository를 직접 호출하던 부분을 메서드로 분리 */
+    // 센서 ID로 Sensor 엔티티 조회
+    public Sensor getSensorById(String sensorId) {
+        return repo.findBySensorId(sensorId)
+            .orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.NOT_FOUND, "존재하지 않는 센서 ID: " + sensorId));
     }
 }

--- a/src/main/java/com/factoreal/backend/service/SensorService.java
+++ b/src/main/java/com/factoreal/backend/service/SensorService.java
@@ -58,8 +58,15 @@ public class SensorService {
     // 센서 전체 리스트 조회
     public List<SensorDto> getAllSensors() {
         return repo.findAll().stream()
-        .map(s -> new SensorDto(s.getSensorId(), s.getSensorType().toString(), s.getZone().getZoneId(), s.getEquip().getEquipId(), s.getSensorThres(), s.getAllowVal()))
-        .collect(Collectors.toList());
+            .map(s -> new SensorDto(
+                s.getSensorId(),
+                s.getSensorType().toString(),
+                s.getZone().getZoneId(),
+                s.getEquip().getEquipId(),
+                s.getSensorThres(),
+                s.getAllowVal()
+            ))
+            .collect(Collectors.toList());
     }
 
     // Sensor Table 업데이트

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,9 +5,9 @@ spring:
       on-profile: local
 
   kafka:
-    bootstrap-servers: ${KAFKA_HOST}:9092
+    bootstrap-servers: localhost:9092
     consumer:
-      group-id: default-consumer-group-sh
+      group-id: default-consumer-group-1
 
   datasource:
     url: jdbc:mysql://127.0.0.1:3306/my_database


### PR DESCRIPTION
## 📌 PR 제목  
feat | sprint2 | FRB-143 | 센서 임계치·허용치 반영 및 자동제어 메시지 로직 추가 | 윤다인

---  

## ✨ 변경 사항  
- SensorUpdateDto에 `sensorThres`(임계치)와 `allowVal`(허용치) 필드 추가  
- SensorService.updateSensor()에 `sensorThres`·`allowVal` 저장 로직 추가
- SensorDto에 `sensorThres`·`allowVal` 필드 추가, `fromEntity()`/`getAllSensors()` 매핑 업데이트  
- KafkaConsumer에 자동제어 로직 분리: `performAutoControl()` 메서드 구현  
  - `(임계치 ± 허용치)` 범위 벗어날 때 센서 타입별로 `ex) "온도가 %.1f℃입니다. 적정 온도로 조절해주세요. (임계치: %.1f℃)"` 양식의 메시지 생성  
  - 추후 MQTT publish 로직 TODO 표시  
- SystemLogDto에 `value`(측정값) 필드 추가, `sendSystemLog()` 호출 시 value 전달  
- 시스템 로그 타임스탬프를 `ZonedDateTime.now(ZoneId.of("Asia/Seoul"))` + `ISO_LOCAL_DATE_TIME` 포맷으로 변경  

---  

## 📸 스크린샷 (선택)  
| 변경 전 | 변경 후 |  
|--------|--------|  
| (이미지) | (이미지) |  

---  

## ✅ 체크리스트  
- [x] 코드에 불필요한 부분은 없는가?  
- [x] 기능이 정상 동작하는가?  
- [x] 의존성은 문제가 없는가?  
- [x] 커밋 메시지는 명확한가?  

---  

## 📎 관련 이슈  
관련된 이슈 번호: 없음  

---  

## 💬 추가 설명  
- `performAutoControl()` 단위 테스트 추가 필요  
- 추후 `mqttClient.publish(...)` 호출로 자동제어 메시지 전송 구현 예정  
