### PR TITLE
fix | sprint3 | FRB-182 | 머지 하면서 발생한 오류 수정 | 김우영

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/equip/dao/EquipHistoryRepository.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/dao/EquipHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.factoreal.backend.domain.equip.dao;
+
+import com.factoreal.backend.domain.equip.entity.EquipHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EquipHistoryRepository extends JpaRepository<EquipHistory, Long> {
+}

--- a/src/main/java/com/factoreal/backend/domain/equip/entity/EquipHistory.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/entity/EquipHistory.java
@@ -1,0 +1,28 @@
+package com.factoreal.backend.domain.equip.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "equip_hist")
+public class EquipHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 설비 기록 PK
+
+    @JoinColumn(name = "equip_id", referencedColumnName = "equip_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Equip equip;
+
+    @Column(name = "date", length = 255, nullable = false)
+    private LocalDateTime date;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private EquipHistoryType type;
+
+
+}

--- a/src/main/java/com/factoreal/backend/domain/equip/entity/EquipHistoryType.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/entity/EquipHistoryType.java
@@ -1,0 +1,6 @@
+package com.factoreal.backend.domain.equip.entity;
+
+public enum EquipHistoryType {
+    UPDATE,
+    ACCIDENT
+}

--- a/src/main/resources/db/migration/V9__add_equip_history_table.sql
+++ b/src/main/resources/db/migration/V9__add_equip_history_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `equip_hist` (
+    `id`	BIGINT	NOT NULL AUTO_INCREMENT,
+    `equip_id`	VARCHAR(100)	NOT NULL,
+    `date`	TIMESTAMP	NULL,
+    `type`	VARCHAR(20)	NULL	COMMENT 'UPDATE(설비 점검) ACCIDENT(ML에서 발생한 경고)',
+    primary key (id),
+    CONSTRAINT FK_equip_info_to_equip_hist FOREIGN KEY (equip_id) references equip_info(equip_id)
+);
+


### PR DESCRIPTION
## 📌 PR 제목
작업자 조회시, 작업자 위치, 상태 반환하도록 수정

---

## ✨ 변경 사항
- 작업자 이전 위치, 이전 상태가 없을 경우, getOrDefault를 사용하여 기본값 반환

---

## 📸 스크린샷 (선택)
| 변경 전 | 변경 후 |
|--------|--------|
| (이미지) | (이미지) |

---

## ✅ 체크리스트
- [ ] 코드에 불필요한 부분은 없는가?
- [ ] 기능이 정상 동작하는가?
- [ ] 의존성은 문제가 없는가?
- [ ] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 번호: #123

---

## 💬 추가 설명
- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요.
