### PR TITLE
feat | sprint3 | FRB-88 | 설비 예상 점검일 예측 결과에 따른 Slack 알림 기능 구현(FastAPI 테스트 완료) | 윤다인

### DIFF
--- a/src/main/java/com/factoreal/backend/BackendApplication.java
+++ b/src/main/java/com/factoreal/backend/BackendApplication.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @OpenAPIDefinition(
 		info = @Info(
@@ -15,6 +16,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 )
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/api/AbnormalController.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/api/AbnormalController.java
@@ -7,8 +7,6 @@ import com.factoreal.backend.domain.abnormalLog.dto.TargetType;
 import com.factoreal.backend.domain.abnormalLog.dto.request.AbnormalPagingRequest;
 import com.factoreal.backend.domain.abnormalLog.dto.response.AbnormalLogResponse;
 import com.factoreal.backend.domain.abnormalLog.dto.response.GradeSummaryResponse;
-import com.factoreal.backend.domain.abnormalLog.dto.response.MonthlyDetailResponse;
-import com.factoreal.backend.domain.abnormalLog.entity.AbnormalLog;
 import com.factoreal.backend.messaging.sender.WebSocketSender;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/factoreal/backend/domain/equip/api/EquipMaintenanceController.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/api/EquipMaintenanceController.java
@@ -1,0 +1,26 @@
+package com.factoreal.backend.domain.equip.api;
+
+import com.factoreal.backend.domain.equip.application.EquipMaintenanceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "(JUnit 테스트용) 설비 점검일자 기한 알림", description = "머신러닝 설비의 예상 점검일자 관련 API")
+@RestController
+@RequestMapping("/api/equip-maintenance")
+@RequiredArgsConstructor
+public class EquipMaintenanceController {
+
+    private final EquipMaintenanceService equipMaintenanceService;
+
+    @Operation(summary = "공장 관리자에게 설비 점검일자 D-5, D-3 때마다 알림 발송", description = "모든 설비의 예상 점검일을 확인하고 필요시 알림을 발송합니다.")
+    @PostMapping("/check")
+    public ResponseEntity<String> checkMaintenanceDates() {
+        equipMaintenanceService.checkMaintenanceDates();
+        return ResponseEntity.ok("점검일 확인 완료");
+    }
+} 

--- a/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
@@ -63,10 +63,14 @@ public class EquipMaintenanceService {
                     if (slackEquipAlarmService.shouldSendAlert(expectedMaintenanceDate)) {
                         slackEquipAlarmService.sendEquipmentMaintenanceAlert(
                             equipment.getEquipName(),
+                            equipment.getZoneName(),
                             expectedMaintenanceDate,
                             daysUntilMaintenance
                         );
-                        log.info("설비 [{}] 점검 알림 발송 완료 (D-{})", equipment.getEquipName(), daysUntilMaintenance);
+                        log.info("설비 [{}] (공간: {}) 점검 알림 발송 완료 (D-{})", 
+                            equipment.getEquipName(), 
+                            equipment.getZoneName(), 
+                            daysUntilMaintenance);
                     }
                 }
             } catch (IOException e) {

--- a/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
@@ -1,0 +1,79 @@
+package com.factoreal.backend.domain.equip.application;
+
+import com.factoreal.backend.domain.equip.dto.response.EquipInfoResponse;
+import com.factoreal.backend.domain.equip.dto.response.MaintenancePredictionResponse;
+import com.factoreal.backend.messaging.slack.service.SlackEquipAlarmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EquipMaintenanceService {
+
+    private final EquipRepoService equipRepoService;
+    private final SlackEquipAlarmService slackEquipAlarmService;
+    private final RestTemplate restTemplate;
+
+    @Value("${fastapi.base-url}")
+    private String fastApiBaseUrl;
+
+    @Value("${fastapi.predict-endpoint}")
+    private String predictEndpoint;
+
+    @Scheduled(cron = "0 0 9 * * *") // 매일 오전 9시에 실행
+    public void checkMaintenanceDates() {
+        log.info("설비 점검일 확인 작업 시작");
+
+        List<EquipInfoResponse> equipments = equipRepoService.findAll();
+
+        for (EquipInfoResponse equipment : equipments) {
+            try {
+                // FastAPI URL 생성 (query parameter 방식)
+                String url = UriComponentsBuilder
+                    .fromUriString(fastApiBaseUrl)
+                    .path(predictEndpoint)
+                    .queryParam("equipId", equipment.getEquipId())
+                    .queryParam("zoneId", equipment.getZoneId())
+                    .toUriString();
+
+                log.info("Calling FastAPI with URL: {}", url);
+
+                // FastAPI로부터 예상 점검일 조회
+                ResponseEntity<MaintenancePredictionResponse> response = 
+                    restTemplate.getForEntity(url, MaintenancePredictionResponse.class);
+
+                // 예상 점검일이 있는 경우
+                if (response.getBody() != null) {
+                    LocalDate expectedMaintenanceDate = response.getBody().getExpectedMaintenanceDate();
+                    // 예상 점검일과 현재 날짜의 차이 계산
+                    long daysUntilMaintenance = slackEquipAlarmService.getDaysUntilMaintenance(expectedMaintenanceDate);
+
+                    // 알림 전송 조건 확인
+                    if (slackEquipAlarmService.shouldSendAlert(expectedMaintenanceDate)) {
+                        slackEquipAlarmService.sendEquipmentMaintenanceAlert(
+                            equipment.getEquipName(),
+                            expectedMaintenanceDate,
+                            daysUntilMaintenance
+                        );
+                        log.info("설비 [{}] 점검 알림 발송 완료 (D-{})", equipment.getEquipName(), daysUntilMaintenance);
+                    }
+                }
+            } catch (IOException e) {
+                log.error("설비 [{}] 점검 알림 발송 실패: {}", equipment.getEquipName(), e.getMessage());
+            } catch (Exception e) {
+                log.error("설비 [{}] 예상 점검일 조회 실패: {}", equipment.getEquipName(), e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/factoreal/backend/domain/equip/dto/response/EquipInfoResponse.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/dto/response/EquipInfoResponse.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+// 설비 정보 응답 DTO
 public class EquipInfoResponse {
     private String equipId;
     private String equipName;

--- a/src/main/java/com/factoreal/backend/domain/equip/dto/response/MaintenancePredictionResponse.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/dto/response/MaintenancePredictionResponse.java
@@ -1,0 +1,16 @@
+package com.factoreal.backend.domain.equip.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+// 설비 점검 예상일 조회 응답 DTO (FastAPI에서 받아온 데이터)
+public class MaintenancePredictionResponse {
+    // 예상 점검일
+    private LocalDate expectedMaintenanceDate;
+} 

--- a/src/main/java/com/factoreal/backend/global/exception/application/SlackService.java
+++ b/src/main/java/com/factoreal/backend/global/exception/application/SlackService.java
@@ -23,7 +23,7 @@ import static com.slack.api.model.block.composition.BlockCompositions.plainText;
 public class SlackService {
     private static final String NEW_LINE = "\n";
     @Value("${webhook.slack.url}")
-    private String SLACK_WEBHOOK_URL;
+    private String SLACK_WEBHOOK_URL; // 채널마다 or 사용자마다 하나씩 발급받아야함
 
     private final Slack slackClient = Slack.getInstance();
 

--- a/src/main/java/com/factoreal/backend/messaging/slack/service/SlackEquipAlarmService.java
+++ b/src/main/java/com/factoreal/backend/messaging/slack/service/SlackEquipAlarmService.java
@@ -26,13 +26,13 @@ public class SlackEquipAlarmService {
     private final Slack slackClient = Slack.getInstance();
 
     // 설비 점검 알림 전송
-    public void sendEquipmentMaintenanceAlert(String equipmentName, LocalDate expectedMaintenanceDate, long daysUntilMaintenance) throws IOException {
-        log.info("Sending Slack alert for equipment: {}, expected date: {}, days until: {}", 
-            equipmentName, expectedMaintenanceDate, daysUntilMaintenance);
+    public void sendEquipmentMaintenanceAlert(String equipmentName, String zoneName, LocalDate expectedMaintenanceDate, long daysUntilMaintenance) throws IOException {
+        log.info("Sending Slack alert for equipment: {}, zone: {}, expected date: {}, days until: {}", 
+            equipmentName, zoneName, expectedMaintenanceDate, daysUntilMaintenance);
         log.info("Using webhook URL: {}", SLACK_WEBHOOK_EQUIP_URL);
         
         try {
-            List<LayoutBlock> layoutBlocks = generateLayoutBlock(equipmentName, expectedMaintenanceDate, daysUntilMaintenance);
+            List<LayoutBlock> layoutBlocks = generateLayoutBlock(equipmentName, zoneName, expectedMaintenanceDate, daysUntilMaintenance);
 
             slackClient.send(SLACK_WEBHOOK_EQUIP_URL, WebhookPayloads
                 .payload(p -> p.blocks(layoutBlocks))
@@ -45,23 +45,25 @@ public class SlackEquipAlarmService {
     }
 
     // 설비 점검 알림 레이아웃 블록 생성
-    private List<LayoutBlock> generateLayoutBlock(String equipmentName, LocalDate expectedMaintenanceDate, long daysUntilMaintenance) {
+    private List<LayoutBlock> generateLayoutBlock(String equipmentName, String zoneName, LocalDate expectedMaintenanceDate, long daysUntilMaintenance) {
         return Blocks.asBlocks(
             getHeader("⚠️ 설비 점검 알림"),
             Blocks.divider(),
-            getSection(generateMaintenanceMessage(equipmentName, expectedMaintenanceDate, daysUntilMaintenance))
+            getSection(generateMaintenanceMessage(equipmentName, zoneName, expectedMaintenanceDate, daysUntilMaintenance))
         );
     }
 
     // 설비 점검 알림 메시지 생성
-    private String generateMaintenanceMessage(String equipmentName, LocalDate expectedMaintenanceDate, long daysUntilMaintenance) {
+    private String generateMaintenanceMessage(String equipmentName, String zoneName, LocalDate expectedMaintenanceDate, long daysUntilMaintenance) {
         StringBuilder sb = new StringBuilder();
         sb.append("*[설비명]*").append(NEW_LINE)
           .append(equipmentName).append(NEW_LINE).append(NEW_LINE)
+          .append("*[공간]*").append(NEW_LINE)
+          .append(zoneName).append(NEW_LINE).append(NEW_LINE)
           .append("*[예상 점검일]*").append(NEW_LINE)
           .append(expectedMaintenanceDate).append(NEW_LINE).append(NEW_LINE)
           .append("*[남은 기간]*").append(NEW_LINE)
-          .append("D-").append(daysUntilMaintenance).append(NEW_LINE);
+          .append("🚨D-").append(daysUntilMaintenance).append(NEW_LINE);
 
         return sb.toString();
     }

--- a/src/main/java/com/factoreal/backend/messaging/slack/service/SlackEquipAlarmService.java
+++ b/src/main/java/com/factoreal/backend/messaging/slack/service/SlackEquipAlarmService.java
@@ -1,0 +1,92 @@
+package com.factoreal.backend.messaging.slack.service;
+
+import com.slack.api.Slack;
+import com.slack.api.model.block.Blocks;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.BlockCompositions;
+import com.slack.api.webhook.WebhookPayloads;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Slf4j
+@Service
+public class SlackEquipAlarmService {
+    private static final String NEW_LINE = "\n";
+    
+    @Value("${webhook.slack.equip_url}")
+    private String SLACK_WEBHOOK_EQUIP_URL;
+
+    // Slack 클라이언트 인스턴스 생성
+    private final Slack slackClient = Slack.getInstance();
+
+    // 설비 점검 알림 전송
+    public void sendEquipmentMaintenanceAlert(String equipmentName, LocalDate expectedMaintenanceDate, long daysUntilMaintenance) throws IOException {
+        log.info("Sending Slack alert for equipment: {}, expected date: {}, days until: {}", 
+            equipmentName, expectedMaintenanceDate, daysUntilMaintenance);
+        log.info("Using webhook URL: {}", SLACK_WEBHOOK_EQUIP_URL);
+        
+        try {
+            List<LayoutBlock> layoutBlocks = generateLayoutBlock(equipmentName, expectedMaintenanceDate, daysUntilMaintenance);
+
+            slackClient.send(SLACK_WEBHOOK_EQUIP_URL, WebhookPayloads
+                .payload(p -> p.blocks(layoutBlocks))
+            );
+            log.info("Successfully sent Slack alert");
+        } catch (Exception e) {
+            log.error("Failed to send Slack alert: {}", e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    // 설비 점검 알림 레이아웃 블록 생성
+    private List<LayoutBlock> generateLayoutBlock(String equipmentName, LocalDate expectedMaintenanceDate, long daysUntilMaintenance) {
+        return Blocks.asBlocks(
+            getHeader("⚠️ 설비 점검 알림"),
+            Blocks.divider(),
+            getSection(generateMaintenanceMessage(equipmentName, expectedMaintenanceDate, daysUntilMaintenance))
+        );
+    }
+
+    // 설비 점검 알림 메시지 생성
+    private String generateMaintenanceMessage(String equipmentName, LocalDate expectedMaintenanceDate, long daysUntilMaintenance) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("*[설비명]*").append(NEW_LINE)
+          .append(equipmentName).append(NEW_LINE).append(NEW_LINE)
+          .append("*[예상 점검일]*").append(NEW_LINE)
+          .append(expectedMaintenanceDate).append(NEW_LINE).append(NEW_LINE)
+          .append("*[남은 기간]*").append(NEW_LINE)
+          .append("D-").append(daysUntilMaintenance).append(NEW_LINE);
+
+        return sb.toString();
+    }
+
+    // 설비 점검 알림 레이아웃 블록 헤더 생성
+    private LayoutBlock getHeader(String text) {
+        return Blocks.header(h -> h.text(
+            BlockCompositions.plainText(pt -> pt.emoji(true)
+                .text(text))));
+    }
+
+    // 설비 점검 알림 레이아웃 블록 섹션 생성
+    private LayoutBlock getSection(String message) {
+        return Blocks.section(s ->
+            s.text(BlockCompositions.markdownText(message)));
+    }
+
+    // 설비 점검 알림 전송 조건 확인
+    public boolean shouldSendAlert(LocalDate expectedMaintenanceDate) {
+        long daysUntilMaintenance = ChronoUnit.DAYS.between(LocalDate.now(), expectedMaintenanceDate);
+        return daysUntilMaintenance == 5 || daysUntilMaintenance == 3;
+    }
+
+    // 설비 점검 알림 남은 기간 계산
+    public long getDaysUntilMaintenance(LocalDate expectedMaintenanceDate) {
+        return ChronoUnit.DAYS.between(LocalDate.now(), expectedMaintenanceDate);
+    }
+} 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,7 @@ springdoc:
     resolve-extensions-properties: false
   swagger-ui:
     path: /swagger-ui.html
+
+webhook:
+  slack:
+    equip_url: ${SLACK_WEBHOOK_EQUIP_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,11 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
+# FastAPI URL
+fastapi:
+  base-url: ${FASTAPI_URL:http://localhost:8000}
+  predict-endpoint: /predict-from-s3  # 슬래시(/) 포함
+
 webhook:
   slack:
     equip_url: ${SLACK_WEBHOOK_EQUIP_URL}

--- a/src/test/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -45,7 +46,6 @@ class EquipMaintenanceServiceTest {
 
     @BeforeEach
     void setUp() {
-        // @Value 어노테이션으로 주입되는 값을 테스트 환경에서 직접 설정
         ReflectionTestUtils.setField(equipMaintenanceService, "fastApiBaseUrl", fastApiBaseUrl);
         ReflectionTestUtils.setField(equipMaintenanceService, "predictEndpoint", predictEndpoint);
     }
@@ -55,19 +55,31 @@ class EquipMaintenanceServiceTest {
         // given
         String equipId = "equip_001";
         String equipName = "설비1";
+        String zoneId = "zone_001";
+        String zoneName = "조립라인1";
         LocalDate expectedDate = LocalDate.now().plusDays(5);  // D-5 상황 설정
         
         // 설비 목록 Mock
         EquipInfoResponse equipInfo = new EquipInfoResponse();
         equipInfo.setEquipId(equipId);
         equipInfo.setEquipName(equipName);
+        equipInfo.setZoneId(zoneId);
+        equipInfo.setZoneName(zoneName);
         given(equipRepoService.findAll()).willReturn(List.of(equipInfo));
 
         // FastAPI 응답 Mock
         MaintenancePredictionResponse predictionResponse = new MaintenancePredictionResponse();
         predictionResponse.setExpectedMaintenanceDate(expectedDate);
+        
+        String expectedUrl = UriComponentsBuilder
+            .fromUriString(fastApiBaseUrl)
+            .path(predictEndpoint)
+            .queryParam("equipId", equipId)
+            .queryParam("zoneId", zoneId)
+            .toUriString();
+        
         given(restTemplate.getForEntity(
-            eq(fastApiBaseUrl + predictEndpoint + "/" + equipId),
+            eq(expectedUrl),
             eq(MaintenancePredictionResponse.class)))
             .willReturn(ResponseEntity.ok(predictionResponse));
 
@@ -80,7 +92,7 @@ class EquipMaintenanceServiceTest {
 
         // then
         verify(slackEquipAlarmService, times(1))
-            .sendEquipmentMaintenanceAlert(equipName, expectedDate, 5L);
+            .sendEquipmentMaintenanceAlert(equipName, zoneName, expectedDate, 5L);
     }
 
     @Test
@@ -88,19 +100,31 @@ class EquipMaintenanceServiceTest {
         // given
         String equipId = "equip_001";
         String equipName = "설비1";
+        String zoneId = "zone_001";
+        String zoneName = "조립라인1";
         LocalDate expectedDate = LocalDate.now().plusDays(3);  // D-3 상황 설정
         
         // 설비 목록 Mock
         EquipInfoResponse equipInfo = new EquipInfoResponse();
         equipInfo.setEquipId(equipId);
         equipInfo.setEquipName(equipName);
+        equipInfo.setZoneId(zoneId);
+        equipInfo.setZoneName(zoneName);
         given(equipRepoService.findAll()).willReturn(List.of(equipInfo));
 
         // FastAPI 응답 Mock
         MaintenancePredictionResponse predictionResponse = new MaintenancePredictionResponse();
         predictionResponse.setExpectedMaintenanceDate(expectedDate);
+        
+        String expectedUrl = UriComponentsBuilder
+            .fromUriString(fastApiBaseUrl)
+            .path(predictEndpoint)
+            .queryParam("equipId", equipId)
+            .queryParam("zoneId", zoneId)
+            .toUriString();
+            
         given(restTemplate.getForEntity(
-            eq(fastApiBaseUrl + predictEndpoint + "/" + equipId),
+            eq(expectedUrl),
             eq(MaintenancePredictionResponse.class)))
             .willReturn(ResponseEntity.ok(predictionResponse));
 
@@ -113,7 +137,7 @@ class EquipMaintenanceServiceTest {
 
         // then
         verify(slackEquipAlarmService, times(1))
-            .sendEquipmentMaintenanceAlert(equipName, expectedDate, 3L);
+            .sendEquipmentMaintenanceAlert(equipName, zoneName, expectedDate, 3L);
     }
 
     @Test
@@ -121,19 +145,31 @@ class EquipMaintenanceServiceTest {
         // given
         String equipId = "equip_001";
         String equipName = "설비1";
+        String zoneId = "zone_001";
+        String zoneName = "조립라인1";
         LocalDate expectedDate = LocalDate.now().plusDays(4);  // D-4 상황 설정
         
         // 설비 목록 Mock
         EquipInfoResponse equipInfo = new EquipInfoResponse();
         equipInfo.setEquipId(equipId);
         equipInfo.setEquipName(equipName);
+        equipInfo.setZoneId(zoneId);
+        equipInfo.setZoneName(zoneName);
         given(equipRepoService.findAll()).willReturn(List.of(equipInfo));
 
         // FastAPI 응답 Mock
         MaintenancePredictionResponse predictionResponse = new MaintenancePredictionResponse();
         predictionResponse.setExpectedMaintenanceDate(expectedDate);
+        
+        String expectedUrl = UriComponentsBuilder
+            .fromUriString(fastApiBaseUrl)
+            .path(predictEndpoint)
+            .queryParam("equipId", equipId)
+            .queryParam("zoneId", zoneId)
+            .toUriString();
+            
         given(restTemplate.getForEntity(
-            eq(fastApiBaseUrl + predictEndpoint + "/" + equipId),
+            eq(expectedUrl),
             eq(MaintenancePredictionResponse.class)))
             .willReturn(ResponseEntity.ok(predictionResponse));
 
@@ -145,6 +181,7 @@ class EquipMaintenanceServiceTest {
         equipMaintenanceService.checkMaintenanceDates();
 
         // then
-        verify(slackEquipAlarmService, never()).sendEquipmentMaintenanceAlert(anyString(), any(LocalDate.class), eq(4L));
+        verify(slackEquipAlarmService, never())
+            .sendEquipmentMaintenanceAlert(anyString(), anyString(), any(LocalDate.class), eq(4L));
     }
 } 

--- a/src/test/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceServiceTest.java
@@ -1,0 +1,150 @@
+package com.factoreal.backend.domain.equip.application;
+
+import com.factoreal.backend.domain.equip.dto.response.EquipInfoResponse;
+import com.factoreal.backend.domain.equip.dto.response.MaintenancePredictionResponse;
+import com.factoreal.backend.messaging.slack.service.SlackEquipAlarmService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EquipMaintenanceServiceTest {
+
+    @InjectMocks
+    private EquipMaintenanceService equipMaintenanceService;
+
+    @Mock
+    private EquipRepoService equipRepoService;
+
+    @Mock
+    private SlackEquipAlarmService slackEquipAlarmService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private final String fastApiBaseUrl = "http://localhost:8000";
+    private final String predictEndpoint = "/predict-from-s3";
+
+    @BeforeEach
+    void setUp() {
+        // @Value 어노테이션으로 주입되는 값을 테스트 환경에서 직접 설정
+        ReflectionTestUtils.setField(equipMaintenanceService, "fastApiBaseUrl", fastApiBaseUrl);
+        ReflectionTestUtils.setField(equipMaintenanceService, "predictEndpoint", predictEndpoint);
+    }
+
+    @Test
+    void D5일때_알림이_발송된다() throws IOException {
+        // given
+        String equipId = "equip_001";
+        String equipName = "설비1";
+        LocalDate expectedDate = LocalDate.now().plusDays(5);  // D-5 상황 설정
+        
+        // 설비 목록 Mock
+        EquipInfoResponse equipInfo = new EquipInfoResponse();
+        equipInfo.setEquipId(equipId);
+        equipInfo.setEquipName(equipName);
+        given(equipRepoService.findAll()).willReturn(List.of(equipInfo));
+
+        // FastAPI 응답 Mock
+        MaintenancePredictionResponse predictionResponse = new MaintenancePredictionResponse();
+        predictionResponse.setExpectedMaintenanceDate(expectedDate);
+        given(restTemplate.getForEntity(
+            eq(fastApiBaseUrl + predictEndpoint + "/" + equipId),
+            eq(MaintenancePredictionResponse.class)))
+            .willReturn(ResponseEntity.ok(predictionResponse));
+
+        // D-5 체크 Mock
+        given(slackEquipAlarmService.getDaysUntilMaintenance(expectedDate)).willReturn(5L);
+        given(slackEquipAlarmService.shouldSendAlert(expectedDate)).willReturn(true);
+
+        // when
+        equipMaintenanceService.checkMaintenanceDates();
+
+        // then
+        verify(slackEquipAlarmService, times(1))
+            .sendEquipmentMaintenanceAlert(equipName, expectedDate, 5L);
+    }
+
+    @Test
+    void D3일때_알림이_발송된다() throws IOException {
+        // given
+        String equipId = "equip_001";
+        String equipName = "설비1";
+        LocalDate expectedDate = LocalDate.now().plusDays(3);  // D-3 상황 설정
+        
+        // 설비 목록 Mock
+        EquipInfoResponse equipInfo = new EquipInfoResponse();
+        equipInfo.setEquipId(equipId);
+        equipInfo.setEquipName(equipName);
+        given(equipRepoService.findAll()).willReturn(List.of(equipInfo));
+
+        // FastAPI 응답 Mock
+        MaintenancePredictionResponse predictionResponse = new MaintenancePredictionResponse();
+        predictionResponse.setExpectedMaintenanceDate(expectedDate);
+        given(restTemplate.getForEntity(
+            eq(fastApiBaseUrl + predictEndpoint + "/" + equipId),
+            eq(MaintenancePredictionResponse.class)))
+            .willReturn(ResponseEntity.ok(predictionResponse));
+
+        // D-3 체크 Mock
+        given(slackEquipAlarmService.getDaysUntilMaintenance(expectedDate)).willReturn(3L);
+        given(slackEquipAlarmService.shouldSendAlert(expectedDate)).willReturn(true);
+
+        // when
+        equipMaintenanceService.checkMaintenanceDates();
+
+        // then
+        verify(slackEquipAlarmService, times(1))
+            .sendEquipmentMaintenanceAlert(equipName, expectedDate, 3L);
+    }
+
+    @Test
+    void D4일때_알림이_발송되지_않는다() throws IOException {
+        // given
+        String equipId = "equip_001";
+        String equipName = "설비1";
+        LocalDate expectedDate = LocalDate.now().plusDays(4);  // D-4 상황 설정
+        
+        // 설비 목록 Mock
+        EquipInfoResponse equipInfo = new EquipInfoResponse();
+        equipInfo.setEquipId(equipId);
+        equipInfo.setEquipName(equipName);
+        given(equipRepoService.findAll()).willReturn(List.of(equipInfo));
+
+        // FastAPI 응답 Mock
+        MaintenancePredictionResponse predictionResponse = new MaintenancePredictionResponse();
+        predictionResponse.setExpectedMaintenanceDate(expectedDate);
+        given(restTemplate.getForEntity(
+            eq(fastApiBaseUrl + predictEndpoint + "/" + equipId),
+            eq(MaintenancePredictionResponse.class)))
+            .willReturn(ResponseEntity.ok(predictionResponse));
+
+        // D-4 체크 Mock
+        given(slackEquipAlarmService.getDaysUntilMaintenance(expectedDate)).willReturn(4L);
+        given(slackEquipAlarmService.shouldSendAlert(expectedDate)).willReturn(false);
+
+        // when
+        equipMaintenanceService.checkMaintenanceDates();
+
+        // then
+        verify(slackEquipAlarmService, never()).sendEquipmentMaintenanceAlert(anyString(), any(LocalDate.class), eq(4L));
+    }
+} 


### PR DESCRIPTION
## 📌 PR 제목
feat | sprint3 | FRB-88 | 설비 예상 점검일 예측 결과에 따른 Slack 알림 기능 구현(FastAPI 테스트 완료) | 윤다인

---

## ✨ 변경 사항
- FastAPI 서버로부터 설비별 예상 점검일을 조회하는 기능 구현
- 예상 점검일 D-5, D-3일 때 Slack 알림 발송 기능 구현
- Slack 알림 메시지에 설비명, 공간명, 예상 점검일, 남은 기간 포함
- 알림 발송 성공/실패에 대한 로깅 추가
- 환경 변수를 통한 Slack Webhook URL 설정 구조화

---

## 📸 스크린샷 (선택)
| 알림 메시지 예시 |
|--------|
| ⚠️ 설비 점검 알림<br><br>[설비명]<br>컨베이어 벨트 A<br><br>[공간]<br>조립 라인 1구역<br><br>[예상 점검일]<br>2024-05-10<br><br>[남은 기간]<br>🚨D-5 |

---

## ✅ 체크리스트
- [x] 코드에 불필요한 부분은 없는가?
- [x] 기능이 정상 동작하는가?
- [x] 의존성은 문제가 없는가?
- [x] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 번호: 없음

---

## 💬 추가 설명
### 현재 구현 방식
- 매일 오전 9시에 FastAPI 서버로 예상 점검일 조회
- D-5, D-3일 때만 알림 발송하여 불필요한 알림 최소화
- 환경 변수로 Slack Webhook URL 관리

### 추가 논의 사항
1. **점검 완료 처리**
   - 현재는 예상 점검일 이전에 점검을 완료해도 D-5, D-3 알림이 발송됨
   - 점검 완료 여부를 추적하려면 UI 개발과 DB 스키마 변경이 필요한지 의논 필요
   - 현재는 알림이 2회로 제한되어 있어 큰 문제가 되지 않을 것으로 판단

2. **급격한 이상 상황 대응**
   - 현재는 ML이 센서값만으로 예측한 예상 점검일 기준으로 알림 발송
   - 설비의 급격한 이상 발생 시 즉각적인 알림이 필요할 수 있음
   - 추후 Kafka를 통한 실시간 센서 데이터 모니터링으로 긴급 알림 기능 추가 검토 필요