### PR TITLE
GlobalException에서 BadRequest제대로 처리하지 못하던 오류 수정, abnlog 중복 저장 수정

### DIFF
--- a/src/main/java/com/factoreal/backend/global/common/response/CommonResponseAdvice.java
+++ b/src/main/java/com/factoreal/backend/global/common/response/CommonResponseAdvice.java
@@ -43,7 +43,10 @@ public class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
         if (body instanceof String || body instanceof Resource) {
             return body;
         }
-
+        // ✅ 이미 래핑된 응답은 무시
+        if (body instanceof CommonResponse<?>) {
+            return body;
+        }
         HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
         int status = servletResponse.getStatus();
         HttpStatus httpStatus = HttpStatus.resolve(status);

--- a/src/main/java/com/factoreal/backend/global/exception/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/factoreal/backend/global/exception/api/GlobalExceptionHandler.java
@@ -3,12 +3,15 @@ package com.factoreal.backend.global.exception.api;
 import com.factoreal.backend.global.common.response.CommonResponse;
 import com.factoreal.backend.global.exception.dto.BadRequestException;
 import com.factoreal.backend.global.exception.dto.NotFoundException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class GlobalExceptionHandler {
     @ExceptionHandler(NotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
@@ -18,7 +21,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public CommonResponse<?> handleBadRequestException(NotFoundException e) {
+    public CommonResponse<?> handleBadRequestException(BadRequestException e) {
         return CommonResponse.onFailure(HttpStatus.BAD_REQUEST.value(), e.getMessage());
     }
 }

--- a/src/main/java/com/factoreal/backend/messaging/kafka/consumer/KafkaConsumer.java
+++ b/src/main/java/com/factoreal/backend/messaging/kafka/consumer/KafkaConsumer.java
@@ -34,13 +34,13 @@ public class KafkaConsumer {
     }
 
     // 공간 센서 관련 Kafka 메시지 처리
-    @KafkaListener(topics = "ENVIRONMENT", groupId = "environment-consumer-group-msk")
+    @KafkaListener(topics = "ENVIRONMENT", groupId = "environment-consumer-group-msk-1")
     public void consumeEnvironment(String message) {
         log.info("📩 [ENVIRONMENT] Kafka 메시지 수신: {}", message);
         handleMessage(message, "ENVIRONMENT");
     }
 
-    @KafkaListener(topics = "WEARABLE", groupId = "environment-consumer-group-msk")
+    @KafkaListener(topics = "WEARABLE", groupId = "environment-consumer-group-msk-1")
     public void consumeWearable(String message) {
         log.info("📩 [WEARABLE] Kafka 메시지 수신: {}", message);
         handleWearableMessage(message, "WEARABLE");

--- a/src/main/java/com/factoreal/backend/messaging/kafka/processor/SensorEventProcessor.java
+++ b/src/main/java/com/factoreal/backend/messaging/kafka/processor/SensorEventProcessor.java
@@ -63,12 +63,7 @@ public class SensorEventProcessor {
                 RiskLevel riskLevel = RiskLevel.fromPriority(dangerLevel);
                 TargetType targetType = topicToLogType(topic);
 
-                try {
-                    // 자동 제어 메시지 판단 (Todo - 진행중)
-                    autoControlService.evaluate(dto, dangerLevel);
-                }catch(Exception e){
-                    log.info("자동 제어 기능은 제작중인 기능입니다. Todo 입니다.");
-                }
+
 
                 // WebSocket 알림 전송
                 // 1. 히트맵 전송
@@ -83,7 +78,12 @@ public class SensorEventProcessor {
                     AbnormalLog abnLog = abnormalLogService.saveAbnormalLogFromSensorKafkaDto(
                             dto, sensorType, riskLevel, targetType
                     );
-
+                    try {
+                        // 자동 제어 메시지 판단 (Todo - 진행중)
+                        autoControlService.evaluate(dto, abnLog,dangerLevel);
+                    }catch(Exception e){
+                        log.info("자동 제어 기능은 제작중인 기능입니다. Todo 입니다.");
+                    }
                     // 2-3. 위험 알림 전송 -> 위험도별 Websocket + wearable + Slack(SMS 대체)
                     // Todo : (As-is) 전략 기반 startAlarm() 메서드 담당자 확인 필요
                     // webSocketSender.sendDangerAlarm(abnLog.toAlarmEventDto());

--- a/src/main/java/com/factoreal/backend/messaging/service/AutoControlService.java
+++ b/src/main/java/com/factoreal/backend/messaging/service/AutoControlService.java
@@ -32,7 +32,7 @@ public class AutoControlService {
      * 센서 값이 허용 범위를 벗어났을 경우 제어 메시지를 생성하거나 처리하도록 로깅
      */
     @Transactional
-    public void evaluate(SensorKafkaDto dto, int dangerLevel) {
+    public void evaluate(SensorKafkaDto dto, AbnormalLog abnormalLog,int dangerLevel) {
         if (dangerLevel == 0)
             return; // 정상 범위면 아무 처리 안 함
 
@@ -51,9 +51,6 @@ public class AutoControlService {
         if (value < threshold - tolerance || value > threshold + tolerance) {
             String message = buildControlMessage(sensor.getSensorType().name(), value, threshold, tolerance);
             log.info("⚙️ 자동제어 필요: {}", message);
-
-            // 1. 이상 로그 저장
-            AbnormalLog abnormalLog = abnormalLogService.saveAbnormalLog(dto, sensor, dangerLevel);
 
             // 2. 제어 로그 저장
             String controlType = getControlType(sensor.getSensorType().name());


### PR DESCRIPTION
## 📌 PR 제목
GlobalExceptionHandler 수정, abnLog 중복 저장 수정

---

## ✨ 변경 사항
- GlobalExceptionHandler에서 BadRequestException 타입을 매개변수로 받아야하는데, NotFoundException 타입을 받고 있어 500에러로 반환되던 오류 수정(이제는 404 + 에러에 대한 메세지도 전달하게 바뀜)
- ControlLog에서 Abnlog를 저장하던 로직 수정 + ConcurrentHashMap 기준으로 알람수는 적게 가지만 Control은 매 위험 발생마다 호출되어서 코드 위치를 옮김
---

## 📸 스크린샷 (선택)
| 변경 전 | 변경 후 |
|--------|--------|
| (이미지) | (이미지) |

---

## ✅ 체크리스트
- [ ] 코드에 불필요한 부분은 없는가?
- [ ] 기능이 정상 동작하는가?
- [ ] 의존성은 문제가 없는가?
- [ ] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 번호: #123

---

## 💬 추가 설명
- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요.
