### PR TITLE
feature | sprint3 | FRB-78 | 30일간 이상치 카운팅 그래프 api 구현 | 정민석

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/api/AbnormalController.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/api/AbnormalController.java
@@ -11,6 +11,7 @@ import com.factoreal.backend.domain.abnormalLog.dto.response.GradeSummaryRespons
 import com.factoreal.backend.domain.abnormalLog.dto.response.MonthlyDetailResponse;
 import com.factoreal.backend.domain.abnormalLog.dto.response.MonthlyGradeSummaryResponse;
 import com.factoreal.backend.domain.abnormalLog.dto.response.reportDetailResponse.PeriodDetailReport;
+import com.factoreal.backend.domain.abnormalLog.dto.response.reportGraphResponse.GraphSummaryResponse;
 import com.factoreal.backend.domain.abnormalLog.entity.AbnormalLog;
 import com.factoreal.backend.messaging.sender.WebSocketSender;
 import io.swagger.v3.oas.annotations.Operation;
@@ -110,6 +111,12 @@ public class AbnormalController {
     public ResponseEntity<Void> sendReport() throws Exception {
         reportMailService.sendMonthlyDetailReports();
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/graph-report")
+    @Operation(summary = "지난 30일 그래프용 이상치 횟수 집계", description = "이상치 횟수를 상황별로 보기 위한 api")
+    public GraphSummaryResponse getSummary() {
+        return reportService.buildLast30DaysGraph();
     }
 
 }

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogRepoService.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogRepoService.java
@@ -112,4 +112,8 @@ public class AbnormalLogRepoService{
         );
         return abnormalLog.get();
     }
+
+    public List<AbnormalLog> findByDetectedAtBetweenAndDangerLevelIn(LocalDateTime start, LocalDateTime end, List<Integer> integers) {
+        return abnLogRepository.findByDetectedAtBetweenAndDangerLevelIn(start, end, integers);
+    }
 }

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/application/ReportService.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/application/ReportService.java
@@ -292,7 +292,7 @@ public class ReportService {
 
         /* ① 기간 계산 : 어제~30일 전 */
         LocalDate yesterday = LocalDate.now().minusDays(1);
-        LocalDate startDay  = yesterday.minusDays(29);     // 총 30일
+        LocalDate startDay  = yesterday.minusDays(30);     // 총 30일
 
         LocalDateTime start = startDay.atStartOfDay();
         LocalDateTime end   = yesterday.atTime(LocalTime.MAX);

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/dao/AbnLogRepository.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/dao/AbnLogRepository.java
@@ -49,4 +49,10 @@ public interface AbnLogRepository extends JpaRepository<AbnormalLog,Long> {
         @Param("zone") Zone zone,
         @Param("dangerLevel") Integer dangerLevel
     );
+
+    /**
+     * 30일 기간의 이상치(위험도 1과 2) 에 해당되는 ABN 로그를 불러오는 기능
+     */
+    List<AbnormalLog> findByDetectedAtBetweenAndDangerLevelIn(
+            LocalDateTime start, LocalDateTime end, List<Integer> dangerLevels);
 }

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/dto/response/reportGraphResponse/Bar.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/dto/response/reportGraphResponse/Bar.java
@@ -1,0 +1,14 @@
+package com.factoreal.backend.domain.abnormalLog.dto.response.reportGraphResponse;
+
+import lombok.*;
+
+// Bar.java
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Bar {
+    private String label;   // x 축
+    private long   cnt;     // y 축
+}

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/dto/response/reportGraphResponse/GraphSummaryResponse.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/dto/response/reportGraphResponse/GraphSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.factoreal.backend.domain.abnormalLog.dto.response.reportGraphResponse;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GraphSummaryResponse {
+
+    private String period;
+
+    /** SENSOR / EQUIP / WORKER 건수 */
+    private List<Bar> typeStats;
+
+    /** 30 일 구간 MM-dd 별 건수 */
+    private List<Bar> dateStats;
+
+    /** Zone 별 건수 */
+    private List<Bar> zoneStats;
+}


### PR DESCRIPTION
## 📌 PR 제목
30일간 이상치 카운팅 그래프 api 구현

---

## ✨ 변경 사항
- 전날부터 근 30일간의 이상치의 횟수를 타입별, 시간별, 공간별로 반환해주는 기능 구현

---
