### PR TITLE
[fix] 설비 잔존수명 예측 기능 추가

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/equip/api/EquipSchedulerTestController.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/api/EquipSchedulerTestController.java
@@ -1,0 +1,32 @@
+package com.factoreal.backend.domain.equip.api;
+
+import com.factoreal.backend.domain.equip.application.EquipMaintenanceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Scheduler Test",
+        description = "설비 점검일 예측 스케줄러 강제 실행 테스트 API<br>일정 주기로 실행되는 배치 스케줄러(fetchAndProcessMaintenancePredictions)를 즉시 실행합니다.<br>운영에서는 사용 주의!"
+)
+@RestController
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class EquipSchedulerTestController {
+    private final EquipMaintenanceService equipMaintenanceService;
+
+    @Operation(
+            summary = "설비 점검일 예측 스케줄러 수동 실행",
+            description = "설비별 잔존수명(예상 점검일) 예측을 담당하는 배치 스케줄러(fetchAndProcessMaintenancePredictions)를 강제로 즉시 실행합니다.<br>" +
+                    "스케줄러의 배치 기능이 정상 동작하는지 테스트하거나, 개발 환경에서 수동 호출 용도로 사용하세요.<br>" +
+                    "※ 운영 환경에서는 주의해서 사용하시기 바랍니다."
+    )
+    @PostMapping("/run-maintenance-scheduler")
+    public String runSchedulerNow() {
+        equipMaintenanceService.fetchAndProcessMaintenancePredictions();
+        return "Scheduler 실행 완료!";
+    }
+}

--- a/src/main/java/com/factoreal/backend/domain/equip/application/EquipHistoryRepoService.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/application/EquipHistoryRepoService.java
@@ -20,6 +20,15 @@ public class EquipHistoryRepoService {
         return equipHistoryRepository.save(history);
     }
 
+
+    /**
+     * SELECT *
+     * FROM equip_history
+     * WHERE equip_id = :equipId
+     *   AND check_date IS NULL
+     * ORDER BY id DESC
+     * LIMIT 1;
+     */
     // 설비의 점검 완료되지 않은(checkDate가 null인) 최신 이력 조회
     @Transactional(readOnly = true)
     public Optional<EquipHistory> findLatestUncheckedByEquipId(String equipId) {

--- a/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
@@ -1,11 +1,14 @@
 package com.factoreal.backend.domain.equip.application;
 
-import com.factoreal.backend.domain.equip.dto.response.EquipInfoResponse;
+import com.factoreal.backend.domain.equip.dto.response.EquipPredTargetResponse;
 import com.factoreal.backend.domain.equip.dto.response.MaintenancePredictionResponse;
 import com.factoreal.backend.domain.equip.dto.response.LatestMaintenancePredictionResponse;
 import com.factoreal.backend.domain.equip.entity.Equip;
 import com.factoreal.backend.domain.equip.entity.EquipHistory;
 import com.factoreal.backend.messaging.slack.api.SlackEquipAlarmService;
+import com.factoreal.backend.domain.zone.application.ZoneRepoService;
+import com.factoreal.backend.domain.zone.entity.Zone;
+import com.factoreal.backend.global.exception.dto.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,7 +24,9 @@ import org.springframework.web.server.ResponseStatusException;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -29,6 +34,7 @@ import java.util.Optional;
 public class EquipMaintenanceService {
 
     private final EquipRepoService equipRepoService;
+    private final ZoneRepoService  zoneRepoService;
     private final EquipHistoryRepoService equipHistoryRepoService;
     private final SlackEquipAlarmService slackEquipAlarmService;
     private final RestTemplate restTemplate;
@@ -147,11 +153,34 @@ public class EquipMaintenanceService {
 
     @Scheduled(cron = "6 0 13/1 * * *") // 매일 13:00:06부터 1시간 간격으로 실행
     public void fetchAndProcessMaintenancePredictions() {
-        log.info("설비 점검일 예측 데이터 수집 시작");
+        log.info("🔄 설비 점검일 예측 데이터 수집 시작");
 
-        List<EquipInfoResponse> equipments = equipRepoService.findAll();
+        // 1. 엔티티 리스트 조회
+        List<Equip> equips = equipRepoService.findEquipsWhereEquipIdNotEqualsZoneId();
 
-        for (EquipInfoResponse equipment : equipments) {
+        // 2. DTO로 변환
+        List<EquipPredTargetResponse> inferenceTargets = equips.stream().map(equip -> {
+            try{
+                // zone 정보가 없으면 예외 발생 (NPE)
+                Zone zone = zoneRepoService.findById(equip.getZone().getZoneId());
+                return EquipPredTargetResponse.fromEntity(equip, zone);
+            }catch (NotFoundException e){
+                // 존재하지 않는 zoneId: 로그만 남기고 null 반환
+                log.warn("📌 존재하지 않는 zoneId: {} (설비: {})", equip.getZone().getZoneId(), equip.getEquipId());
+                return null;
+            }
+        })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+
+
+        log.info("🐤 추론 시작할 설비 : {}", inferenceTargets.stream().toList());
+
+        for (EquipPredTargetResponse equipment : inferenceTargets) {
+            // 개별 설비 정보 로그
+            log.info("=========================");
+            log.info("🔍 [{}] 설비 추론 시작 - [equipId: {}]",equipment.getEquipName(),equipment.getEquipId());
+
             try {
                 // FastAPI URL 생성 (query parameter 방식)
                 String url = UriComponentsBuilder
@@ -161,16 +190,22 @@ public class EquipMaintenanceService {
                         .queryParam("zoneId", equipment.getZoneId())
                         .toUriString();
 
-                log.info("FastAPI 호출 - URL: {}, 설비: [{}]", url, equipment.getEquipName());
+                log.info("💡FastAPI 호출 - URL: {}, 설비: [{}]", url, equipment.getEquipName());
 
                 // FastAPI로부터 예상 점검일 조회
                 ResponseEntity<MaintenancePredictionResponse> response =
                         restTemplate.getForEntity(url, MaintenancePredictionResponse.class);
 
+                log.info("➡️설비 점검 일자 추론 호출 결과 (FastAPI) : {}" , response);
+                log.info("➡️설비 점검 일자 추론 결과 (FastAPI) : {}" , response.getBody().getPredictions().get(0));
+
+                Integer remainDays = response.getBody().getPredictions().get(0).intValue();
+
+
                 // 예상 점검일이 있는 경우
-                if (response.getBody() != null && response.getBody().getRemainingDays() != null) {
+                if (response.getBody() != null && remainDays != null) {
                     // 남은 일수를 예상 점검일자로 변환
-                    LocalDate expectedMaintenanceDate = calculateExpectedMaintenanceDate(response.getBody().getRemainingDays());
+                    LocalDate expectedMaintenanceDate = calculateExpectedMaintenanceDate(remainDays);
 
                     // 예상 점검일자 처리 및 DB 저장
                     processMaintenancePrediction(equipment.getEquipId(), expectedMaintenanceDate);
@@ -180,7 +215,7 @@ public class EquipMaintenanceService {
 
                     log.info("설비 [{}] 예측 결과 수신 - 잔존 수명: {}일, 예상 점검일: {}, D-{}",
                             equipment.getEquipName(),
-                            response.getBody().getRemainingDays(),
+                            remainDays,
                             expectedMaintenanceDate,
                             daysUntilMaintenance);
 

--- a/src/main/java/com/factoreal/backend/domain/equip/application/EquipRepoService.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/application/EquipRepoService.java
@@ -61,4 +61,10 @@ public class EquipRepoService {
                 })
                 .collect(Collectors.toList());
     }
+
+
+    // equipId와 zoneId가 다른 설비 엔티티 리스트 반환
+    public List<Equip> findEquipsWhereEquipIdNotEqualsZoneId() {
+        return equipRepo.findAllWhereEquipIdNotEqualsZoneId();
+    }
 }

--- a/src/main/java/com/factoreal/backend/domain/equip/dao/EquipRepository.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/dao/EquipRepository.java
@@ -10,6 +10,9 @@ import com.factoreal.backend.domain.equip.entity.Equip;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+/**
+ * 설비 엔티티(JPA)의 Repository
+ */
 public interface EquipRepository extends JpaRepository<Equip, String> {
     Optional<Equip> findByEquipId(String equipId);
 
@@ -20,4 +23,8 @@ public interface EquipRepository extends JpaRepository<Equip, String> {
 //    List<Equip> findFacilitiesByZone(@Param("zone") Zone zone);
 
     List<Equip> findEquipsByZone(@Param("zone") Zone zone);
+
+    // equipId와 zone.zoneId가 다른 설비만 조회하는 JPA 쿼리
+    @Query("SELECT e FROM Equip e WHERE e.equipId <> e.zone.zoneId")
+    List<Equip> findAllWhereEquipIdNotEqualsZoneId();
 }

--- a/src/main/java/com/factoreal/backend/domain/equip/dto/response/EquipPredTargetResponse.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/dto/response/EquipPredTargetResponse.java
@@ -1,0 +1,32 @@
+package com.factoreal.backend.domain.equip.dto.response;
+
+import com.factoreal.backend.domain.equip.entity.Equip;
+import com.factoreal.backend.domain.zone.entity.Zone;
+import lombok.*;
+
+
+/**
+ * 설비 추론 대상 정보를 응답으로 내려주는 DTO
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class EquipPredTargetResponse {
+    private String equipId;
+    private String equipName;
+    private String zoneId;
+    private String zoneName;
+
+    // 엔티티(Equip)와 존(Zone) 정보를 바탕으로 DTO 생성
+    public static EquipPredTargetResponse fromEntity(Equip equip, Zone zone) {
+        return EquipPredTargetResponse.builder()
+                .equipId(equip.getEquipId())
+                .equipName(equip.getEquipName())
+                .zoneId(equip.getZone() != null ? equip.getZone().getZoneId() : null)
+                .zoneName(zone != null ? zone.getZoneName() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/factoreal/backend/domain/equip/dto/response/MaintenancePredictionResponse.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/dto/response/MaintenancePredictionResponse.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
 // 설비 점검 예상일 조회 응답 DTO (FastAPI에서 받아온 데이터)
 public class MaintenancePredictionResponse {
-    @JsonProperty("remaining_days")
-    private Integer remainingDays; // ML 모델이 예측한 잔존 수명 (남은 일수)
+
+    private String status; // "ok" or "error" 등
+    private List<Double> predictions; // // ML 모델이 예측한 잔존 수명 (남은 일수)
 } 

--- a/src/main/java/com/factoreal/backend/messaging/kafka/consumer/KafkaConsumer.java
+++ b/src/main/java/com/factoreal/backend/messaging/kafka/consumer/KafkaConsumer.java
@@ -34,13 +34,13 @@ public class KafkaConsumer {
     }
 
     // 공간 센서 관련 Kafka 메시지 처리
-    @KafkaListener(topics = "ENVIRONMENT", groupId = "environment-consumer-group-msk-2")
+    @KafkaListener(topics = "ENVIRONMENT", groupId = "environment-consumer-group-sh-2")
     public void consumeEnvironment(String message) {
         log.info("📩 [ENVIRONMENT] Kafka 메시지 수신: {}", message);
         handleMessage(message, "ENVIRONMENT");
     }
 
-    @KafkaListener(topics = "WEARABLE", groupId = "environment-consumer-group-msk-1")
+    @KafkaListener(topics = "WEARABLE", groupId = "environment-consumer-group-sh-1")
     public void consumeWearable(String message) {
         log.info("📩 [WEARABLE] Kafka 메시지 수신: {}", message);
         handleWearableMessage(message, "WEARABLE");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,7 +94,7 @@ grafana:
 # FastAPI URL
 fastapi:
   base-url: ${FASTAPI_URL:http://localhost:8000}
-  predict-endpoint: /predict-from-s3  # 슬래시(/) 포함
+  predict-endpoint: /predict  # 슬래시(/) 포함
 
 webhook:
   slack:


### PR DESCRIPTION
## 📌 PR 제목
[fix] 설비 잔존수명 예측 기능 추가
<!-- ex: [feat] 로그인 기능 추가 -->

---

## ✨ 변경 사항
- EquipMaintenanceService.java 수정
- application.yaml fastAPI endpoint 수정

---

## 📸 스크린샷 
### 1. (스프링 로그) 기능 호출시 DB에 있는 설비 포문 돌면서 fastAPI 호출
<img width="1351" alt="스크린샷 2025-06-10 오후 1 39 48" src="https://github.com/user-attachments/assets/a9b04141-68aa-4b65-8c58-00e73c7c34db" />

### 2.  (fastAPI 로그) 설비별 잔존 수명 예측
<img width="1251" alt="스크린샷 2025-06-10 오후 1 41 28" src="https://github.com/user-attachments/assets/924b73c2-0c6a-458a-9e6d-88565bfde9cd" />


---

## ✅ 체크리스트
- [x] 코드에 불필요한 부분은 없는가?
- [x] 기능이 정상 동작하는가?
- [x] 의존성은 문제가 없는가?
- [x] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 번호: https://facto-real.atlassian.net/browse/FRB-228

---

## 💬 추가 설명
- N/A
