### PR TITLE
test | 없음 | 없음 | FCM null 체크 로직, 동시성 로직 변경을 테스트 코드에 반영 | 김우영

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/worker/application/WorkerRepoService.java
+++ b/src/main/java/com/factoreal/backend/domain/worker/application/WorkerRepoService.java
@@ -60,4 +60,9 @@ public class WorkerRepoService {
     public boolean existsByEmail(String email){
         return workerRepository.existsByEmail(email);
     }
+
+    public Worker lockWorkerRow(String workerId){
+        return workerRepository.findWorkersByWorkerId(workerId);
+    }
+
 }

--- a/src/main/java/com/factoreal/backend/domain/worker/dao/WorkerRepository.java
+++ b/src/main/java/com/factoreal/backend/domain/worker/dao/WorkerRepository.java
@@ -1,7 +1,10 @@
 package com.factoreal.backend.domain.worker.dao;
 
 import com.factoreal.backend.domain.worker.entity.Worker;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
@@ -17,4 +20,8 @@ public interface WorkerRepository extends JpaRepository<Worker, String> {
     boolean existsByPhoneNumber(String phoneNumber);
 
     boolean existsByEmail(String email);
+
+    // 예시 코드
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Worker findWorkersByWorkerId(@Param("workerId") String workerId);
 }

--- a/src/main/java/com/factoreal/backend/domain/zone/application/ZoneHistoryRepoService.java
+++ b/src/main/java/com/factoreal/backend/domain/zone/application/ZoneHistoryRepoService.java
@@ -3,7 +3,9 @@ package com.factoreal.backend.domain.zone.application;
 import com.factoreal.backend.domain.worker.entity.Worker;
 import com.factoreal.backend.domain.zone.dao.ZoneHistoryRepository;
 import com.factoreal.backend.domain.zone.entity.ZoneHist;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +42,7 @@ public class ZoneHistoryRepoService {
      * 공간에 대한 히스토리 저장하는 레포 접근 메서드
      */
     @Transactional
+
     protected ZoneHist save(ZoneHist zoneHist) {
         return zoneHistoryRepository.save(zoneHist);
     }
@@ -52,6 +55,10 @@ public class ZoneHistoryRepoService {
         return zoneHistoryRepository.findByWorker_WorkerIdAndExistFlag(worker.getWorkerId(), existFlag);
     }
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    public ZoneHist findByWorkerLocateForUpdate(String workerId) {
+        return zoneHistoryRepository.findByWorker_WorkerIdAndExistFlag(workerId, 1);
+    }
     /**
      * 작업자가 존재하는 존재하는 공간 히스토리들을 조회
      * existFlag는 boolean 타입과 같은 개념으로 0 혹은 1이 들어옵니다.

--- a/src/main/java/com/factoreal/backend/domain/zone/application/ZoneHistoryService.java
+++ b/src/main/java/com/factoreal/backend/domain/zone/application/ZoneHistoryService.java
@@ -2,15 +2,19 @@ package com.factoreal.backend.domain.zone.application;
 
 import com.factoreal.backend.domain.state.store.InMemoryZoneWorkerStateStore;
 import com.factoreal.backend.domain.worker.application.WorkerRepoService;
+import com.factoreal.backend.domain.worker.application.WorkerZoneRepoService;
 import com.factoreal.backend.domain.worker.entity.Worker;
+import com.factoreal.backend.domain.worker.entity.WorkerZone;
 import com.factoreal.backend.domain.zone.entity.Zone;
 import com.factoreal.backend.domain.zone.entity.ZoneHist;
+import com.factoreal.backend.global.exception.dto.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -21,6 +25,7 @@ public class ZoneHistoryService {
     private final ZoneHistoryRepoService zoneHistoryRepoService;
     private final ZoneRepoService zoneRepoService;
     private final WorkerRepoService workerRepoService;
+    private final WorkerZoneRepoService workerZoneRepoService;
 
     /**
      * 작업자의 위치 변경을 처리
@@ -32,7 +37,18 @@ public class ZoneHistoryService {
 
         // 1. State 변경 (메모리 상태)
         zoneWorkerStateStore.setWorkerRiskLevel(zoneId, workerId, zoneWorkerStateStore.getWorkerRiskLevel(workerId));
+        // 0.5 작업자가 해당 zone 출입 권한을 가지고 있는지 확인
+        List<WorkerZone> availableZones = workerZoneRepoService.findByWorker_WorkerId(workerId);
+        // WorkerZone > zone 의 Id와 zoneId와 매치되는지 검증
+        boolean isZoneValid = availableZones.stream()
+            .anyMatch(workerZone ->
+                workerZone.getZone() != null && // Zone 객체가 null이 아닌지 안전하게 확인
+                    workerZone.getZone().getZoneId().equals(zoneId)
+            );
 
+        if (!isZoneValid) {
+            throw new BadRequestException(String.format("작업자 ID: %s는 공간 ID: %s에 대한 접근 권한이 없습니다.", workerId, zoneId));
+        }
         // 2. 이전 위치 종료 처리
         ZoneHist currentLocation = zoneHistoryRepoService.findByWorkerLocateForUpdate(workerId);
         if (currentLocation != null) {

--- a/src/main/java/com/factoreal/backend/domain/zone/application/ZoneHistoryService.java
+++ b/src/main/java/com/factoreal/backend/domain/zone/application/ZoneHistoryService.java
@@ -27,36 +27,34 @@ public class ZoneHistoryService {
      */
     @Transactional
     public void updateWorkerLocation(String workerId, String zoneId, LocalDateTime timestamp) {
-        // 0. State 변경
+        // 0. 작업자에 대한 락 선점
+        Worker lockedWorker = workerRepoService.lockWorkerRow(workerId);  // 락 획득
+
+        // 1. State 변경 (메모리 상태)
         zoneWorkerStateStore.setWorkerRiskLevel(zoneId, workerId, zoneWorkerStateStore.getWorkerRiskLevel(workerId));
 
-        // 1. workerId 기반 작업자의 이전 위치가 있으면, 새로운 기록 생성 전 해당 작업자 위치 기록에 endTime 찍어주기
-        ZoneHist currentLocation = zoneHistoryRepoService.getCurrentWorkerLocation(workerId);
+        // 2. 이전 위치 종료 처리
+        ZoneHist currentLocation = zoneHistoryRepoService.findByWorkerLocateForUpdate(workerId);
         if (currentLocation != null) {
-            currentLocation.setEndTime(timestamp); // 다음 공간의 입장 시간으로 update
+            currentLocation.setEndTime(timestamp);
             currentLocation.setExistFlag(0);
             zoneHistoryRepoService.save(currentLocation);
         }
 
-        // 2. 새로운 위치 기록 생성
-        Worker worker = workerRepoService.findById(workerId);
+        // 3. 새로운 위치 기록
         Zone zone = zoneRepoService.findById(zoneId);
         ZoneHist newLocation = ZoneHist.builder()
-                .worker(worker)
-                .zone(zone)
-                .startTime(timestamp)
-                .endTime(null)
-                .existFlag(1)
-                .build();
-
+            .worker(lockedWorker)  // 이미 락 잡힌 worker 사용
+            .zone(zone)
+            .startTime(timestamp)
+            .endTime(null)
+            .existFlag(1)
+            .build();
         zoneHistoryRepoService.save(newLocation);
 
-        /**
-         * currentLocation이 있으면 (이전 위치가 있으면) -> 그 공간의 ID를 출력
-         * currentLocation이 없으면 (최초 입장이면) -> "없음" 출력
-         */
+        // 4. 로그 출력
         log.info("작업자 {} 위치 변경: {} -> {}", workerId,
-                currentLocation != null ? currentLocation.getZone().getZoneId() : "없음",
-                zoneId);
+            currentLocation != null ? currentLocation.getZone().getZoneId() : "없음",
+            zoneId);
     }
 }

--- a/src/main/java/com/factoreal/backend/domain/zone/dao/ZoneHistoryRepository.java
+++ b/src/main/java/com/factoreal/backend/domain/zone/dao/ZoneHistoryRepository.java
@@ -2,6 +2,7 @@ package com.factoreal.backend.domain.zone.dao;
 
 import com.factoreal.backend.domain.zone.entity.ZoneHist;
 import jakarta.persistence.LockModeType;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 
@@ -12,7 +13,6 @@ public interface ZoneHistoryRepository extends JpaRepository<ZoneHist, Long> {
     List<ZoneHist> findByZone_ZoneIdAndExistFlag(String zoneId, Integer existFlag);
 
     // 특정 작업자의 현재 위치 조회 (existFlag = 1)
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     ZoneHist findByWorker_WorkerIdAndExistFlag(String workerId, Integer existFlag);
 
     List<ZoneHist> findByWorker_WorkerId(String workerId);

--- a/src/main/java/com/factoreal/backend/messaging/fcm/application/FCMPushService.java
+++ b/src/main/java/com/factoreal/backend/messaging/fcm/application/FCMPushService.java
@@ -19,18 +19,16 @@ public class FCMPushService {
 
 //   TODO 트러블 슈팅 -> 비동기에서 예외처리 방법
     @Async
-    public CompletableFuture<String> sendMessage(String token, String title, String body) throws FirebaseMessagingException {
+    public CompletableFuture<String> sendMessage(String token, String title, String body) {
+        if (token == null) {
+            return CompletableFuture.failedFuture(new IllegalArgumentException("fcm 토큰 없음"));
+        }
         try {
             String message = firebaseMessaging.send(
-                    Message.builder()
-                            .setNotification(
-                                    Notification.builder()
-                                            .setTitle(title)
-                                            .setBody(body)
-                                            .build()
-                            )
-                            .setToken(token)
-                            .build()
+                Message.builder()
+                    .setNotification(Notification.builder().setTitle(title).setBody(body).build())
+                    .setToken(token)
+                    .build()
             );
             log.info("FCM 전송 성공: {}", message);
             return CompletableFuture.completedFuture(message);

--- a/src/main/java/com/factoreal/backend/messaging/kafka/consumer/KafkaConsumer.java
+++ b/src/main/java/com/factoreal/backend/messaging/kafka/consumer/KafkaConsumer.java
@@ -34,13 +34,13 @@ public class KafkaConsumer {
     }
 
     // 공간 센서 관련 Kafka 메시지 처리
-//    @KafkaListener(topics = "ENVIRONMENT", groupId = "${spring.kafka.consumer.group-id:env-group}")
+    @KafkaListener(topics = "ENVIRONMENT", groupId = "${spring.kafka.consumer.group-id:env-group}")
     public void consumeEnvironment(String message) {
         log.info("📩 [ENVIRONMENT] Kafka 메시지 수신: {}", message);
         handleMessage(message, "ENVIRONMENT");
     }
 
-//    @KafkaListener(topics = "WEARABLE", groupId = "${spring.kafka.consumer.group-id:env-group}")
+    @KafkaListener(topics = "WEARABLE", groupId = "${spring.kafka.consumer.group-id:env-group}")
     public void consumeWearable(String message) {
         log.info("📩 [WEARABLE] Kafka 메시지 수신: {}", message);
         handleWearableMessage(message, "WEARABLE");

--- a/src/main/java/com/factoreal/backend/messaging/kafka/strategy/alarmList/AppPushNotificationStrategy.java
+++ b/src/main/java/com/factoreal/backend/messaging/kafka/strategy/alarmList/AppPushNotificationStrategy.java
@@ -28,6 +28,9 @@ public class AppPushNotificationStrategy implements NotificationStrategy {
         log.info("📲 App Push Notification Strategy.");
         // 1. 같은 공간에 있는 작업자에게 FCM 푸시 알람 전송
         List<WorkerInfoResponse> workerList = workerService.getWorkersByZoneId(alarmEventResponse.getZoneId());
+        if(workerList.isEmpty()){
+            return;
+        }
         AbnormalLog abnormalLog = abnormalLogRepoService.findById(alarmEventResponse.getEventId());
         workerList.forEach(worker -> {
             fcmService.sendZoneSafety(
@@ -38,7 +41,6 @@ public class AppPushNotificationStrategy implements NotificationStrategy {
                     abnormalLog
             );
         });
-        // 2. notify 로그에 저장
     }
 
     @Override

--- a/src/test/java/com/factoreal/backend/domain/zone/application/ZoneHistoryServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/zone/application/ZoneHistoryServiceTest.java
@@ -168,10 +168,6 @@ class ZoneHistoryServiceTest {
         given(zoneWorkerStateStore.getWorkerRiskLevel(workerId))
                 .willReturn(RiskLevel.INFO);
 
-        // 작업자의 현재 위치 정보가 없음을 설정 (최초 입장 상황)
-//        given(zoneHistoryRepoService.getCurrentWorkerLocation(workerId))
-//                .willReturn(null);
-
         // 작업자 정보 조회 시 미리 생성한 worker 객체 반환
         given(workerRepoService.lockWorkerRow(workerId))
                 .willReturn(worker);
@@ -301,7 +297,6 @@ class ZoneHistoryServiceTest {
         String workerId = "20250001";
         String newZoneId = "20250507165751-826";  // zone3의 ID
         LocalDateTime newTimestamp = timestamp;
-        given(workerZoneRepoService.findByWorker_WorkerId(workerId)).willReturn(List.of(workerZone1, workerZone2));
 
         // 작업자의 현재 위험 수준을 INFO로 설정 (정상 상태)
         given(zoneWorkerStateStore.getWorkerRiskLevel(workerId))

--- a/src/test/java/com/factoreal/backend/domain/zone/application/ZoneHistoryServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/zone/application/ZoneHistoryServiceTest.java
@@ -96,11 +96,11 @@ class ZoneHistoryServiceTest {
                 .willReturn(RiskLevel.INFO);
 
         // 작업자의 현재 위치 정보 반환 (zone1에 있음)
-        given(zoneHistoryRepoService.getCurrentWorkerLocation(workerId))
+        given(zoneHistoryRepoService.findByWorkerLocateForUpdate(workerId))
                 .willReturn(currentLocation);
 
         // 작업자 정보 조회 시 미리 생성한 worker 객체 반환
-        given(workerRepoService.findById(workerId))
+        given(workerRepoService.lockWorkerRow(workerId))
                 .willReturn(worker);
 
         // 새로운 위치(zone2) 정보 조회 시 미리 생성한 zone2 객체 반환
@@ -149,11 +149,11 @@ class ZoneHistoryServiceTest {
                 .willReturn(RiskLevel.INFO);
 
         // 작업자의 현재 위치 정보가 없음을 설정 (최초 입장 상황)
-        given(zoneHistoryRepoService.getCurrentWorkerLocation(workerId))
-                .willReturn(null);
+//        given(zoneHistoryRepoService.getCurrentWorkerLocation(workerId))
+//                .willReturn(null);
 
         // 작업자 정보 조회 시 미리 생성한 worker 객체 반환
-        given(workerRepoService.findById(workerId))
+        given(workerRepoService.lockWorkerRow(workerId))
                 .willReturn(worker);
 
         // 새로운 위치(zone1) 정보 조회 시 미리 생성한 zone1 객체 반환
@@ -191,15 +191,15 @@ class ZoneHistoryServiceTest {
         String newZoneId = "20250507165750-827";  // zone1의 ID
 
         // 작업자의 현재 위험 수준을 INFO로 설정 (정상 상태)
-        given(zoneWorkerStateStore.getWorkerRiskLevel(workerId))
-                .willReturn(RiskLevel.INFO);
+//        given(zoneWorkerStateStore.getWorkerRiskLevel(workerId))
+//                .willReturn(RiskLevel.INFO);
 
         // 작업자의 현재 위치 정보가 없음을 설정
-        given(zoneHistoryRepoService.getCurrentWorkerLocation(workerId))
-                .willReturn(null);
+//        given(zoneHistoryRepoService.getCurrentWorkerLocation(workerId))
+//                .willReturn(null);
 
         // 작업자 정보 조회 시 미리 생성한 worker 객체 반환
-        given(workerRepoService.findById(workerId))
+        given(workerRepoService.lockWorkerRow(workerId))
                 .willReturn(worker);
 
         // 새로운 위치(zone1) 정보 조회 시 미리 생성한 zone1 객체 반환
@@ -243,11 +243,11 @@ class ZoneHistoryServiceTest {
                 .willReturn(RiskLevel.WARNING);
 
         // 작업자의 현재 위치 정보가 없음을 설정
-        given(zoneHistoryRepoService.getCurrentWorkerLocation(workerId))
-                .willReturn(null);
+//        given(zoneHistoryRepoService.getCurrentWorkerLocation(workerId))
+//                .willReturn(null);
 
         // 작업자 정보 조회 시 미리 생성한 worker 객체 반환
-        given(workerRepoService.findById(workerId))
+        given(workerRepoService.lockWorkerRow(workerId))
                 .willReturn(worker);
 
         // 새로운 위치(zone1) 정보 조회 시 미리 생성한 zone1 객체 반환


### PR DESCRIPTION
## 📌 PR 제목
<!-- ex: [feat] 로그인 기능 추가 -->
FCM null 체크 로직, 동시성 로직 변경을 테스트 코드에 반영

---

## ✨ 변경 사항
- 비관적 쓰기 락을 적용하여 동시성 문제 해결(worker, zonehistory)
- FCM 호출 직전에 FCMToken을 확인하여 null이면 호출하지 않도록 수정
- AppPushNotificationStrategy에서 Worker 목록이 없으면 바로 return 하도록 수정
- 위의 변경 사항에 따른 테스트 코드 수정
  - FCMServiceTest에서 null체크 확인으로 인해 예외 처리 테스트 케이스 제거 
---