### PR TITLE
fix | 기능 테스트 | 없음 | WorkerInfoResponse에 status 필드 추가 & ZoneHistory 업데이트 시 공간 접근 권한 검증 | 조수빈

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/worker/application/WorkerService.java
+++ b/src/main/java/com/factoreal/backend/domain/worker/application/WorkerService.java
@@ -157,10 +157,7 @@ public class WorkerService {
 
         // 2-2. 해당 zone의 담당자 ID가 작업자 ID와 같은지 확인
         Optional<WorkerZone> zoneManager = workerZoneRepoService.findByZoneZoneIdAndManageYnIsTrue(zoneId);
-        if (zoneManager.isEmpty()) {
-            return null;
-        }
-       String managerId = zoneManager.get().getWorker().getWorkerId();
+        String managerId = zoneManager.map(wz -> wz.getWorker().getWorkerId()).orElse(null);
 
         // 3. AbnormalLog 에서 작업자 상태 조회
         List<AbnormalLogResponse> statusList = abnormalLogService.

--- a/src/test/java/com/factoreal/backend/domain/zone/application/ZoneHistoryServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/zone/application/ZoneHistoryServiceTest.java
@@ -2,7 +2,9 @@ package com.factoreal.backend.domain.zone.application;
 
 import com.factoreal.backend.domain.state.store.InMemoryZoneWorkerStateStore;
 import com.factoreal.backend.domain.worker.application.WorkerRepoService;
+import com.factoreal.backend.domain.worker.application.WorkerZoneRepoService;
 import com.factoreal.backend.domain.worker.entity.Worker;
+import com.factoreal.backend.domain.worker.entity.WorkerZone;
 import com.factoreal.backend.domain.zone.entity.Zone;
 import com.factoreal.backend.domain.zone.entity.ZoneHist;
 import com.factoreal.backend.messaging.kafka.strategy.enums.RiskLevel;
@@ -45,8 +47,12 @@ class ZoneHistoryServiceTest {
     @Captor
     private ArgumentCaptor<ZoneHist> zoneHistCaptor;
 
+    @Mock
+    private WorkerZoneRepoService workerZoneRepoService;
+
     private Worker worker;
-    private Zone zone1, zone2;
+    private Zone zone1, zone2, zone3;
+    private WorkerZone workerZone1, workerZone2;
     private ZoneHist currentLocation;
     private LocalDateTime timestamp;
 
@@ -71,6 +77,15 @@ class ZoneHistoryServiceTest {
                 .zoneName("B구역")
                 .build();
 
+        zone3 = Zone.builder()
+                .zoneId("20250507165751-826")
+                .zoneName("C구역")
+                .build();
+
+        // 테스트용 WorkerZone 데이터 생성: zone1, zone2에 대해 권한 부여
+        workerZone1 = WorkerZone.builder().worker(worker).zone(zone1).manageYn(false).build();
+        workerZone2 = WorkerZone.builder().worker(worker).zone(zone2).manageYn(false).build();
+
         // 테스트용 현재 위치 데이터 생성
         timestamp = LocalDateTime.of(2025, 5, 7, 16, 57, 50);
         currentLocation = ZoneHist.builder()
@@ -90,6 +105,7 @@ class ZoneHistoryServiceTest {
         String workerId = "20250001";
         String newZoneId = "20250507165751-828";  // zone2의 ID
         LocalDateTime newTimestamp = timestamp;
+        given(workerZoneRepoService.findByWorker_WorkerId(workerId)).willReturn(List.of(workerZone1, workerZone2));
 
         // 작업자의 현재 위험 수준을 INFO로 설정 (정상 상태)
         given(zoneWorkerStateStore.getWorkerRiskLevel(workerId))
@@ -143,6 +159,8 @@ class ZoneHistoryServiceTest {
         String workerId = "20250001";
         String newZoneId = "20250507165750-827";  // zone1의 ID
         LocalDateTime newTimestamp = timestamp;
+        given(workerZoneRepoService.findByWorker_WorkerId(workerId)).willReturn(List.of(workerZone1, workerZone2));
+
 
         // 작업자의 현재 위험 수준을 INFO로 설정 (정상 상태)
         given(zoneWorkerStateStore.getWorkerRiskLevel(workerId))
@@ -189,6 +207,8 @@ class ZoneHistoryServiceTest {
         // given
         String workerId = "20250001";
         String newZoneId = "20250507165750-827";  // zone1의 ID
+        given(workerZoneRepoService.findByWorker_WorkerId(workerId)).willReturn(List.of(workerZone1, workerZone2));
+
 
         // 작업자의 현재 위험 수준을 INFO로 설정 (정상 상태)
         given(zoneWorkerStateStore.getWorkerRiskLevel(workerId))
@@ -237,6 +257,8 @@ class ZoneHistoryServiceTest {
         String workerId = "20250001";
         String newZoneId = "20250507165750-827";  // zone1의 ID
         LocalDateTime newTimestamp = timestamp;
+        given(workerZoneRepoService.findByWorker_WorkerId(workerId)).willReturn(List.of(workerZone1, workerZone2));
+
 
         // 작업자의 현재 위험 수준을 WARNING으로 설정 (경고 상태)
         given(zoneWorkerStateStore.getWorkerRiskLevel(workerId))
@@ -269,4 +291,5 @@ class ZoneHistoryServiceTest {
         verify(zoneWorkerStateStore, times(1))
                 .setWorkerRiskLevel(newZoneId, workerId, RiskLevel.WARNING);
     }
+
 } 


### PR DESCRIPTION
## 📌 PR 제목
fix | 기능 테스트 | 없음 | WorkerInfoResponse에 status 필드 추가 & ZoneHistory 업데이트 시 공간 접근 권한 검증 | 조수빈\

---

## ✨ 변경 사항
- WorkerZoneServiceTest 시 해당 zone에 manager가 없을 경우 무조건 null을 반환하는 문제 해결
- zoneHistoryServiceTest 시 공간에 대한 권한 검증 및 예외처리 코드 추가 

---

## 📸 스크린샷 (선택)
| 변경 전 | 변경 후 |
|--------|--------|
| (이미지) | (이미지) |

---

## ✅ 체크리스트
- [ ] 코드에 불필요한 부분은 없는가?
- [ ] 기능이 정상 동작하는가?
- [ ] 의존성은 문제가 없는가?
- [ ] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 번호: #123

---

## 💬 추가 설명
- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요.
