### PR TITLE
fix | 기능 테스트 | FRB-241 | 공간 담당자 조회 시 status 필드 존재하지 않는 문제 수정 | 조수빈

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/application/ReportMailService.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/application/ReportMailService.java
@@ -5,6 +5,7 @@ import com.factoreal.backend.domain.abnormalLog.dto.response.reportDetailRespons
 import com.factoreal.backend.domain.controlLog.entity.ControlLog;
 import com.factoreal.backend.domain.controlLog.application.ControlLogRepoService;
 import com.factoreal.backend.domain.worker.application.WorkerManagerService;
+import com.factoreal.backend.domain.worker.dto.response.WorkerInfoResponse;
 import com.factoreal.backend.domain.worker.dto.response.WorkerManagerResponse;
 import com.factoreal.backend.domain.zone.application.ZoneRepoService;
 import com.factoreal.backend.domain.zone.entity.Zone;
@@ -53,7 +54,7 @@ public class ReportMailService {
             String zoneName = zone.getZoneName();
 
             // 공간의 매니저 탐색 후
-            WorkerManagerResponse manager = workerManagerService.getCurrentManager(zoneId);
+            WorkerInfoResponse manager = workerManagerService.getCurrentManager(zoneId);
 
             // 담당자가 없거나 메일이 없으면 skip
             if (manager == null || manager.getEmail() == null || manager.getEmail().isBlank()) {

--- a/src/main/java/com/factoreal/backend/domain/worker/api/WorkerManagerController.java
+++ b/src/main/java/com/factoreal/backend/domain/worker/api/WorkerManagerController.java
@@ -1,5 +1,6 @@
 package com.factoreal.backend.domain.worker.api;
 
+import com.factoreal.backend.domain.worker.dto.response.WorkerInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,10 +42,9 @@ public class WorkerManagerController {
 
   @Operation(summary = "현재 공간 담당자 정보 조회", description = "특정 공간의 현재 담당자 정보를 조회합니다.")
   @GetMapping("/{zoneId}")
-  public ResponseEntity<WorkerManagerResponse> getCurrentManager(
+  public WorkerInfoResponse getCurrentManager(
       @Parameter(description = "공간 ID", required = true) @PathVariable String zoneId) {
     log.info("공간 ID: {}의 현재 담당자 조회 요청", zoneId);
-    WorkerManagerResponse manager = workerManagerService.getCurrentManager(zoneId);
-    return manager != null ? ResponseEntity.ok(manager) : ResponseEntity.noContent().build();
+    return  workerManagerService.getCurrentManager(zoneId);
   }
 }

--- a/src/test/java/com/factoreal/backend/domain/abnormalLog/application/ReportMailServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/abnormalLog/application/ReportMailServiceTest.java
@@ -3,6 +3,7 @@ package com.factoreal.backend.domain.abnormalLog.application;
 import com.factoreal.backend.domain.abnormalLog.dto.response.reportDetailResponse.*;
 import com.factoreal.backend.domain.controlLog.application.ControlLogRepoService;
 import com.factoreal.backend.domain.worker.application.WorkerManagerService;
+import com.factoreal.backend.domain.worker.dto.response.WorkerInfoResponse;
 import com.factoreal.backend.domain.worker.dto.response.WorkerManagerResponse;
 import com.factoreal.backend.domain.zone.application.ZoneRepoService;
 import com.factoreal.backend.domain.zone.entity.Zone;
@@ -47,8 +48,8 @@ class ReportMailServiceTest {
 
     /* ── 공용 더미 ───────────────────────── */
     private Zone z(String id) { return Zone.builder().zoneId(id).zoneName("Z" + id).build(); }
-    private WorkerManagerResponse mgr(String email) {
-        return WorkerManagerResponse.builder()
+    private WorkerInfoResponse mgr(String email) {
+        return WorkerInfoResponse.builder()
                 .workerId("W1").name("홍길동").email(email).isManager(true).build();
     }
 

--- a/src/test/java/com/factoreal/backend/domain/worker/application/WorkerManagerServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/worker/application/WorkerManagerServiceTest.java
@@ -1,5 +1,6 @@
 package com.factoreal.backend.domain.worker.application;
 
+import com.factoreal.backend.domain.worker.dto.response.WorkerInfoResponse;
 import com.factoreal.backend.domain.worker.dto.response.WorkerManagerResponse;
 import com.factoreal.backend.domain.worker.entity.Worker;
 import com.factoreal.backend.domain.worker.entity.WorkerZone;
@@ -204,7 +205,7 @@ class WorkerManagerServiceTest {
                 .willReturn(Optional.of(workerZone1));
 
         // when
-        WorkerManagerResponse manager = workerManagerService.getCurrentManager(zoneId);
+        WorkerInfoResponse manager = workerManagerService.getCurrentManager(zoneId);
 
         // then
         assertThat(manager).isNotNull();
@@ -225,7 +226,7 @@ class WorkerManagerServiceTest {
                 .willReturn(Optional.empty());
 
         // when
-        WorkerManagerResponse manager = workerManagerService.getCurrentManager(zoneId);
+        WorkerInfoResponse manager = workerManagerService.getCurrentManager(zoneId);
 
         // then
         assertThat(manager).isNull();

--- a/src/test/java/com/factoreal/backend/domain/worker/application/WorkerManagerServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/worker/application/WorkerManagerServiceTest.java
@@ -1,5 +1,6 @@
 package com.factoreal.backend.domain.worker.application;
 
+import com.factoreal.backend.domain.abnormalLog.application.AbnormalLogService;
 import com.factoreal.backend.domain.worker.dto.response.WorkerInfoResponse;
 import com.factoreal.backend.domain.worker.dto.response.WorkerManagerResponse;
 import com.factoreal.backend.domain.worker.entity.Worker;
@@ -33,6 +34,9 @@ class WorkerManagerServiceTest {
 
     @InjectMocks
     private WorkerManagerService workerManagerService;
+
+    @Mock
+    private AbnormalLogService abnormalLogService;
 
     private Worker worker1, worker2, worker3;
     private Zone zone1, zone2;


### PR DESCRIPTION
## 📌 PR 제목
fix | 기능 테스트 | FRB-241 | 공간 담당자 조회 시 status 필드 존재하지 않는 문제 수정 | 조수빈

---

## ✨ 변경 사항
- 공간 담당자 조회 시 WorkerManagerResponse를 반환하던 기존 로직에서 WorkerInfoRespons를 반환하도록 변경하였습니다.
- 따라서 공간 담당자 조회 시 담당자의 status 정보도 함께 반환하게 하였습니다. 

---
