### PR TITLE
[feat] 설비 추론 호출 로직 분리 및 테스트 코드 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     implementation 'software.amazon.awssdk:regions'
     implementation 'software.amazon.awssdk:iotdataplane'
     implementation 'software.amazon.awssdk:sns'
+    implementation "software.amazon.awssdk:sqs"
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs:3.3.0" //SQS Starter
+    implementation "com.amazonaws:aws-lambda-java-events:3.15.0" // S3 이벤트 JSON 파싱
 
     // AWS 테스트용 LocalStack
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/src/main/java/com/factoreal/backend/BackendApplication.java
+++ b/src/main/java/com/factoreal/backend/BackendApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+//@EnableScheduling
 @OpenAPIDefinition(
 		info = @Info(
 				title = "Factoreal Swagger API",
@@ -16,7 +17,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 )
 @SpringBootApplication
 @EnableAsync
-@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogService.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogService.java
@@ -4,6 +4,7 @@ import com.factoreal.backend.domain.abnormalLog.dto.TargetType;
 import com.factoreal.backend.domain.abnormalLog.dto.request.AbnormalPagingRequest;
 import com.factoreal.backend.domain.abnormalLog.dto.response.AbnormalLogResponse;
 import com.factoreal.backend.domain.abnormalLog.entity.AbnormalLog;
+import com.factoreal.backend.domain.equip.entity.Equip;
 import com.factoreal.backend.domain.sensor.application.SensorRepoService;
 import com.factoreal.backend.domain.sensor.dao.SensorRepository;
 import com.factoreal.backend.domain.sensor.dto.SensorKafkaDto;
@@ -179,6 +180,7 @@ public class AbnormalLogService {
         return true;
     }
 
+    // 센서 abnormal log 저장
     @Transactional
     public AbnormalLog saveAbnormalLog(SensorKafkaDto dto, Sensor sensor, int dangerLevel) {
         RiskLevel riskLevel = RiskLevel.fromPriority(dangerLevel);
@@ -200,6 +202,30 @@ public class AbnormalLogService {
         return PageRequest.of(
                 abnormalPagingRequest.getPage(),
                 abnormalPagingRequest.getSize());
+    }
+
+    /**
+     * 설비 예측 기반 이상 로그 저장
+     * @param zone 공간 엔티티
+     * @param equip 설비 엔티티
+     * @param remainDays 계산된 잔존 수명(일)
+     * @param dangerLevel 위험 레벨 (1 또는 2)
+     */
+    @Transactional
+    public void saveEquipAbnormalLog(Zone zone, Equip equip, int remainDays, int dangerLevel) {
+        AbnormalLog abnormalLog = AbnormalLog.builder()
+                .targetType(TargetType.Equip)
+                .targetId(equip.getEquipId())
+                .abnormalType("설비 잔존 수명 경고")      // 필요에 따라 상세 메시지로 변경
+                .abnVal((double) remainDays)
+                .dangerLevel(dangerLevel)
+                .zone(zone)
+                .detectedAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+
+        abnormalLogRepoService.save(abnormalLog);
+        log.info("📝 설비 이상 로그 저장 (equipId={}, dangerLevel={})", equip.getEquipId(), dangerLevel);
     }
 
 

--- a/src/main/java/com/factoreal/backend/domain/equip/api/EquipMaintenanceController.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/api/EquipMaintenanceController.java
@@ -16,12 +16,12 @@ public class EquipMaintenanceController {
 
     private final EquipMaintenanceService equipMaintenanceService;
 
-    @Operation(summary = "(스케줄링) 공장 관리자에게 예상 점검일자가 D-5, D-3 인 경우, 알림 발송", description = "모든 설비의 예상 점검일을 확인하고 필요시 알림을 발송합니다.")
-    @PostMapping("/check")
-    public String checkMaintenanceDates() {
-        equipMaintenanceService.fetchAndProcessMaintenancePredictions();
-        return "점검일 확인 완료";
-    }
+//    @Operation(summary = "(스케줄링) 공장 관리자에게 예상 점검일자가 D-5, D-3 인 경우, 알림 발송", description = "모든 설비의 예상 점검일을 확인하고 필요시 알림을 발송합니다.")
+//    @PostMapping("/check")
+//    public String checkMaintenanceDates() {
+//        equipMaintenanceService.fetchAndProcessMaintenancePredictions();
+//        return "점검일 확인 완료";
+//    }
 
     @Operation(
         summary = "특정 설비의 가장 최근 예상 점검일자 조회",

--- a/src/main/java/com/factoreal/backend/domain/equip/api/EquipSchedulerTestController.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/api/EquipSchedulerTestController.java
@@ -1,32 +1,32 @@
-package com.factoreal.backend.domain.equip.api;
-
-import com.factoreal.backend.domain.equip.application.EquipMaintenanceService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@Tag(
-        name = "Scheduler Test",
-        description = "설비 점검일 예측 스케줄러 강제 실행 테스트 API<br>일정 주기로 실행되는 배치 스케줄러(fetchAndProcessMaintenancePredictions)를 즉시 실행합니다.<br>운영에서는 사용 주의!"
-)
-@RestController
-@RequestMapping("/test")
-@RequiredArgsConstructor
-public class EquipSchedulerTestController {
-    private final EquipMaintenanceService equipMaintenanceService;
-
-    @Operation(
-            summary = "설비 점검일 예측 스케줄러 수동 실행",
-            description = "설비별 잔존수명(예상 점검일) 예측을 담당하는 배치 스케줄러(fetchAndProcessMaintenancePredictions)를 강제로 즉시 실행합니다.<br>" +
-                    "스케줄러의 배치 기능이 정상 동작하는지 테스트하거나, 개발 환경에서 수동 호출 용도로 사용하세요.<br>" +
-                    "※ 운영 환경에서는 주의해서 사용하시기 바랍니다."
-    )
-    @PostMapping("/run-maintenance-scheduler")
-    public String runSchedulerNow() {
-        equipMaintenanceService.fetchAndProcessMaintenancePredictions();
-        return "Scheduler 실행 완료!";
-    }
-}
+//package com.factoreal.backend.domain.equip.api;
+//
+//import com.factoreal.backend.domain.equip.application.EquipMaintenanceService;
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//@Tag(
+//        name = "Scheduler Test",
+//        description = "설비 점검일 예측 스케줄러 강제 실행 테스트 API<br>일정 주기로 실행되는 배치 스케줄러(fetchAndProcessMaintenancePredictions)를 즉시 실행합니다.<br>운영에서는 사용 주의!"
+//)
+//@RestController
+//@RequestMapping("/test")
+//@RequiredArgsConstructor
+//public class EquipSchedulerTestController {
+//    private final EquipMaintenanceService equipMaintenanceService;
+//
+//    @Operation(
+//            summary = "설비 점검일 예측 스케줄러 수동 실행",
+//            description = "설비별 잔존수명(예상 점검일) 예측을 담당하는 배치 스케줄러(fetchAndProcessMaintenancePredictions)를 강제로 즉시 실행합니다.<br>" +
+//                    "스케줄러의 배치 기능이 정상 동작하는지 테스트하거나, 개발 환경에서 수동 호출 용도로 사용하세요.<br>" +
+//                    "※ 운영 환경에서는 주의해서 사용하시기 바랍니다."
+//    )
+//    @PostMapping("/run-maintenance-scheduler")
+//    public String runSchedulerNow() {
+//        equipMaintenanceService.fetchAndProcessMaintenancePredictions(zoneId, String zoneName, String equipId, String equipName);
+//        return "Scheduler 실행 완료!";
+//    }
+//}

--- a/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
@@ -1,32 +1,22 @@
 package com.factoreal.backend.domain.equip.application;
 
-import com.factoreal.backend.domain.equip.dto.response.EquipPredTargetResponse;
-import com.factoreal.backend.domain.equip.dto.response.MaintenancePredictionResponse;
 import com.factoreal.backend.domain.equip.dto.response.LatestMaintenancePredictionResponse;
 import com.factoreal.backend.domain.equip.entity.Equip;
 import com.factoreal.backend.domain.equip.entity.EquipHistory;
 import com.factoreal.backend.messaging.slack.api.SlackEquipAlarmService;
 import com.factoreal.backend.domain.zone.application.ZoneRepoService;
-import com.factoreal.backend.domain.zone.entity.Zone;
-import com.factoreal.backend.global.exception.dto.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -81,7 +71,7 @@ public class EquipMaintenanceService {
      * @param remainingDays ML 모델이 예측한 잔존 수명 (남은 일수)
      * @return 예상 점검일자
      */
-    private LocalDate calculateExpectedMaintenanceDate(int remainingDays) {
+    public LocalDate calculateExpectedMaintenanceDate(int remainingDays) {
         return LocalDate.now().plusDays(remainingDays);
     }
 
@@ -151,95 +141,4 @@ public class EquipMaintenanceService {
         equipHistoryRepoService.save(newHistory);
     }
 
-//    @Scheduled(cron = "6 0 13/1 * * *") // 매일 13:00:06부터 1시간 간격으로 실행
-    public void fetchAndProcessMaintenancePredictions() {
-        log.info("🔄 설비 점검일 예측 데이터 수집 시작");
-
-        // 1. 엔티티 리스트 조회
-        List<Equip> equips = equipRepoService.findEquipsWhereEquipIdNotEqualsZoneId();
-
-        // 2. DTO로 변환
-        List<EquipPredTargetResponse> inferenceTargets = equips.stream().map(equip -> {
-            try{
-                // zone 정보가 없으면 예외 발생 (NPE)
-                Zone zone = zoneRepoService.findById(equip.getZone().getZoneId());
-                return EquipPredTargetResponse.fromEntity(equip, zone);
-            }catch (NotFoundException e){
-                // 존재하지 않는 zoneId: 로그만 남기고 null 반환
-                log.warn("📌 존재하지 않는 zoneId: {} (설비: {})", equip.getZone().getZoneId(), equip.getEquipId());
-                return null;
-            }
-        })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
-
-
-        log.info("🐤 추론 시작할 설비 : {}", inferenceTargets.stream().toList());
-
-        for (EquipPredTargetResponse equipment : inferenceTargets) {
-            // 개별 설비 정보 로그
-            log.info("=========================");
-            log.info("🔍 [{}] 설비 추론 시작 - [equipId: {}]",equipment.getEquipName(),equipment.getEquipId());
-
-            try {
-                // FastAPI URL 생성 (query parameter 방식)
-                String url = UriComponentsBuilder
-                        .fromUriString(fastApiBaseUrl)
-                        .path(predictEndpoint)
-                        .queryParam("equipId", equipment.getEquipId())
-                        .queryParam("zoneId", equipment.getZoneId())
-                        .toUriString();
-
-                log.info("💡FastAPI 호출 - URL: {}, 설비: [{}]", url, equipment.getEquipName());
-
-                // FastAPI로부터 예상 점검일 조회
-                ResponseEntity<MaintenancePredictionResponse> response =
-                        restTemplate.getForEntity(url, MaintenancePredictionResponse.class);
-
-                log.info("➡️설비 점검 일자 추론 호출 결과 (FastAPI) : {}" , response);
-                log.info("➡️설비 점검 일자 추론 결과 (FastAPI) : {}" , response.getBody().getPredictions().get(0));
-
-                Integer remainDays = response.getBody().getPredictions().get(0).intValue();
-
-
-                // 예상 점검일이 있는 경우
-                if (response.getBody() != null && remainDays != null) {
-                    // 남은 일수를 예상 점검일자로 변환
-                    LocalDate expectedMaintenanceDate = calculateExpectedMaintenanceDate(remainDays);
-
-                    // 예상 점검일자 처리 및 DB 저장
-                    processMaintenancePrediction(equipment.getEquipId(), expectedMaintenanceDate);
-
-                    // 예상 점검일과 현재 날짜의 차이 계산
-                    long daysUntilMaintenance = slackEquipAlarmService.getDaysUntilMaintenance(expectedMaintenanceDate);
-
-                    log.info("설비 [{}] 예측 결과 수신 - 잔존 수명: {}일, 예상 점검일: {}, D-{}",
-                            equipment.getEquipName(),
-                            remainDays,
-                            expectedMaintenanceDate,
-                            daysUntilMaintenance);
-
-                    // 알림 전송 조건 확인
-                    if (slackEquipAlarmService.shouldSendAlert(expectedMaintenanceDate)) {
-                        slackEquipAlarmService.sendEquipmentMaintenanceAlert(
-                                equipment.getEquipName(),
-                                equipment.getZoneName(),
-                                expectedMaintenanceDate,
-                                daysUntilMaintenance
-                        );
-                        log.info("설비 [{}] (공간: {}) 점검 알림 발송 완료 (D-{})",
-                                equipment.getEquipName(),
-                                equipment.getZoneName(),
-                                daysUntilMaintenance);
-                    }
-                }
-            } catch (IOException e) {
-                log.error("설비 [{}] 점검 알림 발송 실패: {}", equipment.getEquipName(), e.getMessage());
-            } catch (Exception e) {
-                log.error("설비 [{}] 예상 점검일 조회 실패: {}", equipment.getEquipName(), e.getMessage());
-            }
-        }
-
-        log.info("설비 점검일 예측 데이터 수집 완료");
-    }
 }

--- a/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
@@ -151,7 +151,7 @@ public class EquipMaintenanceService {
         equipHistoryRepoService.save(newHistory);
     }
 
-    @Scheduled(cron = "6 0 13/1 * * *") // 매일 13:00:06부터 1시간 간격으로 실행
+//    @Scheduled(cron = "6 0 13/1 * * *") // 매일 13:00:06부터 1시간 간격으로 실행
     public void fetchAndProcessMaintenancePredictions() {
         log.info("🔄 설비 점검일 예측 데이터 수집 시작");
 

--- a/src/main/java/com/factoreal/backend/global/config/AwsServiceConfig.java
+++ b/src/main/java/com/factoreal/backend/global/config/AwsServiceConfig.java
@@ -4,10 +4,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.iotdataplane.IotDataPlaneClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 @Configuration
 public class AwsServiceConfig {
@@ -47,6 +49,14 @@ public class AwsServiceConfig {
         return SnsClient.builder()
                 .region(Region.of(region))
                 .credentialsProvider(this::awsCredentials)
+                .build();
+    }
+
+    @Bean
+    public SqsAsyncClient sqsAsyncClient(AwsBasicCredentials creds) {
+        return SqsAsyncClient.builder()
+                .region(Region.of(region))                       // ← 명시
+                .credentialsProvider(StaticCredentialsProvider.create(creds))
                 .build();
     }
 }

--- a/src/main/java/com/factoreal/backend/messaging/config/SqsMessagingConfig.java
+++ b/src/main/java/com/factoreal/backend/messaging/config/SqsMessagingConfig.java
@@ -1,0 +1,19 @@
+//package com.factoreal.backend.messaging.config;
+//
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+//
+///**
+// *
+// */
+//@Configuration
+//public class SqsMessagingConfig {
+//
+//    @Bean
+//    public MappingJackson2MessageConverter sqsMessageConverter() {
+//        MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+//        converter.setStrictContentTypeMatch(false);
+//        return converter;
+//    }
+//}

--- a/src/main/java/com/factoreal/backend/messaging/sqs/S3EventSqsListener.java
+++ b/src/main/java/com/factoreal/backend/messaging/sqs/S3EventSqsListener.java
@@ -1,0 +1,70 @@
+package com.factoreal.backend.messaging.sqs;
+
+import com.factoreal.backend.domain.equip.application.EquipMaintenanceService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.ArrayList;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor // 이 위치로 옮기고 import 경로도 바꿔주세요
+public class S3EventSqsListener {
+
+    private final EquipMaintenanceService equipMaintenanceService;
+    private final ObjectMapper objectMapper;
+
+    // ① 큐 이름 또는 Queue URL을 value 작성
+    //   (Queue URL 을 쓰면 renaming 걱정 없음)
+    @SqsListener(value = "https://sqs.ap-northeast-2.amazonaws.com/853660505909/S3NewJsonEventAlert")
+    public void handleMessage(String rawMessage) {
+
+        log.info("📥 SQS 메시지 수신: {}", rawMessage);
+        try {
+
+            JsonNode root = objectMapper.readTree(rawMessage);
+
+            // 1) Records 배열이 있으면 그쪽, 없으면 루트 자체를 단일 이벤트로 처리
+            List<JsonNode> events = new ArrayList<>();
+            JsonNode recordsNode = root.path("Records");
+            if (recordsNode.isArray() && recordsNode.size() > 0) {
+                recordsNode.forEach(events::add);
+            } else {
+                events.add(root);
+            }
+
+            // 2) 이벤트별 공통 로직
+            for (JsonNode rec : events) {
+                String eventName = rec.path("eventName").asText("");
+                if (!eventName.startsWith("ObjectCreated")) {
+                    continue;
+                }
+
+                JsonNode s3 = rec.path("s3");
+                String bucket = s3.path("bucket").path("name").asText("");
+                String keyEnc = s3.path("object").path("key").asText("");
+                String key    = URLDecoder.decode(keyEnc, StandardCharsets.UTF_8);
+
+                log.info("➡️ bucket={}, key={}", bucket, key);
+
+                if (key.startsWith("EQUIPMENT/") && key.endsWith(".json")) {
+                    log.info("👀 서비스 호출 예정");
+//                    equipMaintenanceService.fetchAndProcessMaintenancePredictions();
+                }
+            }
+        } catch (Exception e) {
+            log.error("S3 이벤트 파싱 실패", e);
+            // 필요 시 재시도 로직 or 예외 던지기
+        }
+
+
+    }
+}
+

--- a/src/main/java/com/factoreal/backend/messaging/sqs/processor/EquipPredictProcessor.java
+++ b/src/main/java/com/factoreal/backend/messaging/sqs/processor/EquipPredictProcessor.java
@@ -1,0 +1,131 @@
+package com.factoreal.backend.messaging.sqs.processor;
+
+
+import com.factoreal.backend.domain.abnormalLog.application.AbnormalLogService;
+import com.factoreal.backend.domain.equip.application.EquipMaintenanceService;
+import com.factoreal.backend.domain.equip.application.EquipRepoService;
+import com.factoreal.backend.domain.equip.entity.Equip;
+import com.factoreal.backend.domain.zone.application.ZoneRepoService;
+import com.factoreal.backend.domain.zone.entity.Zone;
+import com.factoreal.backend.messaging.slack.api.SlackEquipAlarmService;
+import com.factoreal.backend.domain.equip.dto.response.MaintenancePredictionResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EquipPredictProcessor {
+
+    private final ZoneRepoService zoneRepoService;
+    private final EquipRepoService equipRepoService;
+    private final RestTemplate restTemplate;
+    private final SlackEquipAlarmService slackEquipAlarmService;
+    private final EquipMaintenanceService equipMaintenanceService;
+    private final AbnormalLogService abnormalLogService;
+
+
+    @Value("${fastapi.base-url}")
+    private String fastApiBaseUrl;
+
+    @Value("${fastapi.predict-endpoint}")
+    private String predictEndpoint;
+
+    /**
+     * // fastAPI 호출 프로세스
+    1. zone, equip 여부 확인 후 잔존 수명 추론 (fastAPI)
+    2. 점검 잔존수명 기준으로 알림 발송 (D-5, D-3)
+    3. 점검 잔존수명 기준으로 이상치 저장 (abnormalLog)
+     */
+    public void equipPredProcess(String zoneId, String equipId){
+
+        log.info("=========================");
+        Zone zone;
+        Equip equip;
+
+        try {
+            zone  = zoneRepoService.findById(zoneId);
+            equip = equipRepoService.findById(equipId);
+        } catch (Exception e) {
+            log.warn("⚠️ 유효하지 않은 이벤트, 스킵 (zoneId={}, equipId={}): {}",
+                    zoneId, equipId, e.getMessage());
+            return;
+        }
+
+        log.info("🔍 [{}] 설비 추론 시작 - [equipId={}]", equip.getEquipName(), equipId);
+
+        try {
+            String url = UriComponentsBuilder
+                    .fromUriString(fastApiBaseUrl)
+                    .path(predictEndpoint)
+                    .queryParam("equipId", equipId)
+                    .queryParam("zoneId", zoneId)
+                    .toUriString();
+
+            log.info("💡FastAPI 호출 - URL: {}", url);
+            ResponseEntity<MaintenancePredictionResponse> resp =
+                    restTemplate.getForEntity(url, MaintenancePredictionResponse.class);
+
+            if (resp.getBody() == null || resp.getBody().getPredictions().isEmpty()) {
+                log.warn("⚠️ FastAPI 예측값 없음 (equipId={})", equipId);
+                return;
+            }
+
+
+            int remainDays = resp.getBody().getPredictions().get(0).intValue();
+            log.info("➡️ FastAPI 예측 결과 (remainDays={}일)", remainDays);
+
+            // 남은 일수를 예상 점검일자로 변환
+            LocalDate expectedMaintenanceDate = equipMaintenanceService.calculateExpectedMaintenanceDate(remainDays);
+
+            // 예상 점검일자 처리 및 DB 저장
+            equipMaintenanceService.processMaintenancePrediction(equipId, expectedMaintenanceDate);
+
+            // 예상 점검일과 현재 날짜의 차이 계산
+            long daysUntil = slackEquipAlarmService.getDaysUntilMaintenance(expectedMaintenanceDate);
+
+            log.info("설비 [{}] 예측 결과 수신 - 잔존 수명: {}일, 예상 점검일: {}, D-{}",
+                    equip.getEquipName(),
+                    remainDays,
+                    expectedMaintenanceDate,
+                    daysUntil);
+
+            // 알림 전송 조건 확인
+            if (slackEquipAlarmService.shouldSendAlert(expectedMaintenanceDate)) {
+                slackEquipAlarmService.sendEquipmentMaintenanceAlert(
+                        equip.getEquipName(),
+                        zone.getZoneName(),
+                        expectedMaintenanceDate,
+                        daysUntil
+                );
+                log.info("✅ 알림 전송 완료 (equipId={}, D-{})", equipId, daysUntil);
+            }
+
+            // 위험 레벨 산정 (remainDays <=3 → 레벨2, 3<remainDays<5 → 레벨1)
+            int dangerLevel = remainDays <= 3 ? 2
+                    : (remainDays < 5 ? 1
+                    : 0);  // 0 이면 로그를 남기지 않음
+
+            if (dangerLevel > 0) {
+                abnormalLogService.saveEquipAbnormalLog(zone, equip, remainDays, dangerLevel);
+            }
+
+
+        } catch (IOException e) {
+            log.error("설비 [{}] 점검 알림 발송 실패: {}", equip.getEquipName(), e.getMessage());
+        } catch (Exception e) {
+            log.error("설비 [{}] 예상 점검일 조회 실패: {}", equip.getEquipName(), e.getMessage());
+        }
+
+        log.info("설비 점검일 예측 데이터 수집 완료");
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,8 +9,15 @@ spring:
     consumer:
       group-id: ${KAFKA_CONSUMER_GROUP_ID}
 
+
   datasource:
     url: jdbc:mysql://127.0.0.1:3306/my_database
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: user
     password: factor2al
+
+aws:
+  sqs:
+    listener:
+      max-number-of-messages: 1 # 동시 처리 튜닝용
+      wait-timeout : 5 # long-polling (초)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,10 @@ aws:
   access-key: ${AWS_IAM_ACCESS_KEY}
   secret-key: ${AWS_IAM_SECRET_KEY}
   region: ap-northeast-2
+  sqs:
+    listener:
+      max-number-of-messages: 5 # 동시 처리 튜닝용
+      wait-timeout : 10 # long-polling (초)
 
 firebase:
   json-base64: ${FIREBASE_JSON_BASE64}

--- a/src/test/java/com/factoreal/backend/domain/controlLog/application/ControlLogServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/controlLog/application/ControlLogServiceTest.java
@@ -115,6 +115,7 @@ class ControlLogServiceTest {
         map.values().forEach(System.out::println);
     }
     /* ========== 3) MQTT 발행 실패 → WebSocket 호출 & mqttDelivered=false ========== */
+    @SuppressWarnings("unchecked")
     @Test
     void saveControl_mqttFail_socketStillCalled() {
         // given

--- a/src/test/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceServiceTest.java
+++ b/src/test/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceServiceTest.java
@@ -358,60 +358,6 @@ class EquipMaintenanceServiceTest {
     }
 
     @Nested
-    @DisplayName("FastAPI 연동 테스트")
-    class FastApiTest {
-
-        @Test
-        @DisplayName("FastAPI 응답 body는 있지만 remainingDays가 null인 경우")
-        void whenFastApiResponseRemainingDaysNull_shouldHandleGracefully() {
-            // given
-            MaintenancePredictionResponse predictionResponse = new MaintenancePredictionResponse();
-            predictionResponse.setStatus("ok");
-            predictionResponse.setPredictions(null);
-
-            lenient().when(equipRepoService.findById(anyString())).thenReturn(equip);
-            lenient().when(restTemplate.getForEntity(anyString(), eq(MaintenancePredictionResponse.class)))
-                    .thenReturn(ResponseEntity.ok(predictionResponse));
-
-            // when
-            equipMaintenanceService.fetchAndProcessMaintenancePredictions();
-
-            // then
-            verify(equipHistoryRepoService, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("FastAPI 응답 실패 시 예외 처리")
-        void whenFastApiFailure_shouldHandleException() {
-            // given
-            lenient().when(equipRepoService.findById(anyString())).thenReturn(equip);
-            lenient().when(restTemplate.getForEntity(anyString(), eq(MaintenancePredictionResponse.class)))
-                    .thenThrow(new RuntimeException("API 호출 실패"));
-
-            // when
-            equipMaintenanceService.fetchAndProcessMaintenancePredictions();
-
-            // then
-            verify(equipHistoryRepoService, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("FastAPI 응답이 null인 경우")
-        void whenFastApiResponseNull_shouldHandleGracefully() {
-            // given
-            lenient().when(equipRepoService.findById(anyString())).thenReturn(equip);
-            lenient().when(restTemplate.getForEntity(anyString(), eq(MaintenancePredictionResponse.class)))
-                    .thenReturn(ResponseEntity.ok(null));
-
-            // when
-            equipMaintenanceService.fetchAndProcessMaintenancePredictions();
-
-            // then
-            verify(equipHistoryRepoService, never()).save(any());
-        }
-    }
-
-    @Nested
     @DisplayName("calculateExpectedMaintenanceDate 메서드 테스트")
     class CalculateExpectedMaintenanceDateTest {
 

--- a/src/test/java/com/factoreal/backend/messaging/sqs/processor/EquipPredictProcessorTest.java
+++ b/src/test/java/com/factoreal/backend/messaging/sqs/processor/EquipPredictProcessorTest.java
@@ -1,0 +1,200 @@
+package com.factoreal.backend.messaging.sqs.processor;
+
+import com.factoreal.backend.domain.abnormalLog.application.AbnormalLogService;
+import com.factoreal.backend.domain.equip.application.EquipMaintenanceService;
+import com.factoreal.backend.domain.equip.application.EquipRepoService;
+import com.factoreal.backend.domain.equip.dto.response.MaintenancePredictionResponse;
+import com.factoreal.backend.domain.equip.entity.Equip;
+import com.factoreal.backend.domain.zone.application.ZoneRepoService;
+import com.factoreal.backend.domain.zone.entity.Zone;
+import com.factoreal.backend.messaging.slack.api.SlackEquipAlarmService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+
+/**
+ * 설비 추론 프로세서 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+public class EquipPredictProcessorTest {
+
+    @InjectMocks
+    EquipPredictProcessor processor;
+    @Mock
+    ZoneRepoService zoneRepoService;
+    @Mock
+    EquipRepoService equipRepoService;
+    @Mock
+    RestTemplate restTemplate;
+    @Mock
+    SlackEquipAlarmService slackEquipAlarmService;
+    @Mock
+    EquipMaintenanceService equipMaintenanceService;
+    @Mock
+    AbnormalLogService abnormalLogService;
+
+    private final String baseUrl = "http://localhost:8000";
+    private final String endpoint = "/predict";
+
+    // Zone : 생산라인A, 설비 : 로봇 암 1호기
+    private String zoneId = "20250507165750-827";
+    private String equipId = "'20250507171316-389'";
+    private Zone zone;
+    private Equip equip;
+
+    @BeforeEach
+    void setUp() {
+        // (MockitoExtension 썼으면 openMocks 불필요)
+        ReflectionTestUtils.setField(processor, "fastApiBaseUrl", baseUrl);
+        ReflectionTestUtils.setField(processor, "predictEndpoint", endpoint);
+
+        zone = Zone.builder().zoneId(zoneId).zoneName("생산 라인 A").build();
+        equip = Equip.builder().equipId(equipId).equipName("로봇 암 1호기").zone(zone).build();
+    }
+
+    @Test
+    @DisplayName("정상 흐름: FastAPI가 remainDays=4 반환 → processMaintenancePrediction 호출")
+    void whenFastApiReturns_validPrediction_thenProcessAndAlertAndLog() throws IOException {
+        // given
+        // 🚩 각 테스트 안에서만 필요한 스텁을 선언
+        given(zoneRepoService.findById(zoneId)).willReturn(zone);
+        given(equipRepoService.findById(equipId)).willReturn(equip);
+
+        MaintenancePredictionResponse apiResp = new MaintenancePredictionResponse();
+        apiResp.setStatus("ok");
+        apiResp.setPredictions(Collections.singletonList(4.0));
+
+        given(zoneRepoService.findById(zoneId)).willReturn(zone);
+        given(equipRepoService.findById(equipId)).willReturn(equip);
+        String expectedUrl = UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .path(endpoint)
+                .queryParam("equipId", equipId)
+                .queryParam("zoneId", zoneId)
+                .toUriString();
+
+        given(restTemplate.getForEntity(eq(expectedUrl),
+                eq(MaintenancePredictionResponse.class)))
+                .willReturn(ResponseEntity.ok(apiResp));
+        given(equipMaintenanceService.calculateExpectedMaintenanceDate(4))
+                .willReturn(LocalDate.now().plusDays(4));
+        given(slackEquipAlarmService.getDaysUntilMaintenance(any())).willReturn(4L);
+        given(slackEquipAlarmService.shouldSendAlert(any())).willReturn(true);
+
+        // when
+        processor.equipPredProcess(zoneId, equipId);
+
+        // then
+        then(equipMaintenanceService).should(times(1))
+                .processMaintenancePrediction(eq(equipId), any(LocalDate.class));
+        then(slackEquipAlarmService).should(times(1))
+                .sendEquipmentMaintenanceAlert(eq("로봇 암 1호기"), eq("생산 라인 A"),  any(LocalDate.class), eq(4L));
+        then(abnormalLogService).should(times(1))
+                .saveEquipAbnormalLog(eq(zone), eq(equip), eq(4), eq(1)); // remainDays=4 → dangerLevel=1
+    }
+
+    @Test
+    @DisplayName("FastAPI 예측값 없으면 아무 동작 안 함")
+    void whenFastApiReturnsEmpty_thenSkip() {
+        // given
+        MaintenancePredictionResponse apiResp = new MaintenancePredictionResponse();
+        apiResp.setStatus("ok");
+        apiResp.setPredictions(Collections.emptyList());
+
+        given(zoneRepoService.findById(zoneId)).willReturn(zone);
+        given(equipRepoService.findById(equipId)).willReturn(equip);
+        given(restTemplate.getForEntity(anyString(), eq(MaintenancePredictionResponse.class)))
+                .willReturn(ResponseEntity.ok(apiResp));
+
+        // when
+        processor.equipPredProcess(zoneId, equipId);
+
+        // then
+        then(equipMaintenanceService).shouldHaveNoInteractions();
+        then(slackEquipAlarmService).shouldHaveNoInteractions();
+        then(abnormalLogService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 zone/equip 들어오면 로그만 남기고 리턴")
+    void whenInvalidZoneOrEquip_thenSkipSilently() {
+        // given: zone 조회만 실패하게 override
+        given(zoneRepoService.findById(zoneId))
+                .willThrow(new RuntimeException("not found"));
+
+        // when
+        processor.equipPredProcess(zoneId, equipId);
+
+        // then: 아무 interaction 도 없어야 함
+        then(restTemplate).shouldHaveNoInteractions();
+        then(equipMaintenanceService).shouldHaveNoInteractions();
+        then(slackEquipAlarmService).shouldHaveNoInteractions();
+        then(abnormalLogService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("remainDays=2일 때 dangerLevel=2로 AbnormalLog 저장")
+    void whenRemainDays2_thenDangerLevel2AbnormalLogSaved() throws IOException {
+        // given
+        MaintenancePredictionResponse apiResp = new MaintenancePredictionResponse();
+        apiResp.setStatus("ok");
+        apiResp.setPredictions(Collections.singletonList(2.0));  // remainDays = 2
+
+        given(zoneRepoService.findById(zoneId)).willReturn(zone);
+        given(equipRepoService.findById(equipId)).willReturn(equip);
+
+        String expectedUrl = UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .path(endpoint)
+                .queryParam("equipId", equipId)
+                .queryParam("zoneId", zoneId)
+                .toUriString();
+        given(restTemplate.getForEntity(eq(expectedUrl), eq(MaintenancePredictionResponse.class)))
+                .willReturn(ResponseEntity.ok(apiResp));
+
+        // calculateExpectedMaintenanceDate, getDaysUntilMaintenance, shouldSendAlert 동작도 모킹
+        LocalDate predictedDate = LocalDate.now().plusDays(2);
+        given(equipMaintenanceService.calculateExpectedMaintenanceDate(2))
+                .willReturn(predictedDate);
+        given(slackEquipAlarmService.getDaysUntilMaintenance(predictedDate))
+                .willReturn(2L);
+        given(slackEquipAlarmService.shouldSendAlert(predictedDate))
+                .willReturn(true);
+
+        // when
+        processor.equipPredProcess(zoneId, equipId);
+
+        // then
+        // 1) processMaintenancePrediction 호출
+        then(equipMaintenanceService).should().processMaintenancePrediction(eq(equipId), eq(predictedDate));
+        // 2) slack 알림
+        then(slackEquipAlarmService).should().sendEquipmentMaintenanceAlert(
+                eq(equip.getEquipName()),
+                eq(zone.getZoneName()),
+                eq(predictedDate),
+                eq(2L)
+        );
+        // 3) dangerLevel = 2 로 abnormalLog 저장
+        then(abnormalLogService).should().saveEquipAbnormalLog(eq(zone), eq(equip), eq(2), eq(2));
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 제목
<!-- ex: [feat] 로그인 기능 추가 -->

---

## ✨ 변경 사항
- sqs messaging build.gradle 수정
- 설비 추론 호출 로직 분리 
    .(as-is) 스케줄링 방식으로 EquipMaintenanceService. fetchAndProcessMaintenancePredictions()
    .(to-be) SQS listener 방식으로 EquipPredictProcessor. equipPredProcess()
- 관련 테스트 코드 수정
- 설비 이상치 테이블 저장 기능 추가
    .설비 추론 일자가 5일 이내면 danger Level 1 , 3일 이내면 danger Level 2로 abn_log 테이블에 저장
- ControlLogTest gradle 경고 수정 (런타임 실패는 아님)

---

## ✅ 체크리스트
- [x] 코드에 불필요한 부분은 없는가?
- [x] 기능이 정상 동작하는가?
- [x] 의존성은 문제가 없는가?
- [x] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 번호: https://facto-real.atlassian.net/browse/FRB-228

---

## 💬 추가 설명
- N/A
