### PR TITLE
fix | sprint3 | FRB-74 | 그래프와 상세로그 조회의 데이터가 일치하지 않던 문제 해결했습니다 (db 시간 저장 로직 문제) | 정민석

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogRepoService.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogRepoService.java
@@ -34,11 +34,13 @@ public class AbnormalLogRepoService{
 
     public List<AbnormalLog> findPreview30daysLog(){
         // ① 오늘 날짜와 30일 전 시각 계산
-        LocalDateTime now        = LocalDateTime.now().minusDays(1);          // 현재 시각
-        LocalDateTime thirtyDays = now.minusDays(30);            // 30일 전
+        LocalDate endBeforeFormat = LocalDate.now().minusDays(1);          // 오늘
+        LocalDate startBeforeFormat = endBeforeFormat.minusDays(30);        // 30일 전
+        LocalDateTime start = startBeforeFormat.atStartOfDay();
+        LocalDateTime end = endBeforeFormat.atTime(LocalTime.MAX);
 
         // ② DB 조회 + dangerLevel 1,2 필터
-        return abnLogRepository.findByDetectedAtBetween(thirtyDays, now)
+        return abnLogRepository.findByDetectedAtBetween(start, end)
                 .stream()
                 .filter(l -> {
                     Integer dl = l.getDangerLevel();

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/application/ReportService.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/application/ReportService.java
@@ -83,8 +83,10 @@ public class ReportService {
      */
     /* 2) 전달 한 달치 A/B/C 등급 요약 */
     public MonthlyGradeSummaryResponse getPrevMonthGrade() {
-        LocalDate end = LocalDate.now().minusDays(1);          // 오늘
-        LocalDate start = end.minusDays(30);        // 30일 전
+        LocalDate endBeforeFormat = LocalDate.now().minusDays(1);          // 오늘
+        LocalDate startBeforeFormat = endBeforeFormat.minusDays(30);        // 30일 전
+        LocalDateTime start = startBeforeFormat.atStartOfDay();
+        LocalDateTime end = endBeforeFormat.atTime(LocalTime.MAX);
 
         DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
@@ -119,8 +121,10 @@ public class ReportService {
      * 전날 기준 최근 30일 이상치 조회
      */
     public PeriodDetailReportResponse buildLast30DaysReport() {
-        LocalDateTime end = LocalDateTime.now().minusDays(1);
-        LocalDateTime start = end.minusDays(30);
+        LocalDate endBeforeFormat = LocalDate.now().minusDays(1);          // 오늘
+        LocalDate startBeforeFormat = endBeforeFormat.minusDays(30);        // 30일 전
+        LocalDateTime start = startBeforeFormat.atStartOfDay();
+        LocalDateTime end = endBeforeFormat.atTime(LocalTime.MAX);
 
         List<AbnormalLog> logs = abnormalLogRepoService.findPreview30daysLog();
 


### PR DESCRIPTION
## 📌 PR 제목
그래프와 상세로그 조회의 데이터가 일치하지 않던 문제 해결했습니다 (db 시간 저장 로직 문제)

---

## ✨ 변경 사항
- 서비스 추가 수정

---