### PR TITLE
그래프 이상치 횟수 response 추가, Dto 수정

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogRepoService.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogRepoService.java
@@ -10,10 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
-import javax.swing.text.html.Option;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/application/ReportService.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/application/ReportService.java
@@ -305,6 +305,14 @@ public class ReportService {
         List<AbnormalLog> logs = abnormalLogRepoService.findByDetectedAtBetweenAndDangerLevelIn(
                 start, end, List.of(1, 2));
 
+        int totalAbnCnt = logs.size();
+        int warnCnt = (int) logs.stream()
+                .filter(l -> l.getDangerLevel() == 1)
+                .count();
+        int dangerCnt = (int) logs.stream()
+                .filter(l -> l.getDangerLevel() == 2)
+                .count();
+
         /* ③ 그래프 1 : TargetType 별 ─ 항상 3개(SENSOR/EQUIP/WORKER) 보장 */
         Map<TargetType, Long> typeCntMap = logs.stream()
                 .collect(Collectors.groupingBy(AbnormalLog::getTargetType, Collectors.counting()));
@@ -336,6 +344,6 @@ public class ReportService {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy.MM.dd");
         String period = f.format(startDay) + " ~ " + f.format(yesterday);
 
-        return new GraphSummaryResponse(period, typeStats, dateStats, zoneStats);
+        return new GraphSummaryResponse( period, totalAbnCnt, warnCnt, dangerCnt, typeStats, dateStats, zoneStats);
     }
 }

--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/dto/response/reportGraphResponse/GraphSummaryResponse.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/dto/response/reportGraphResponse/GraphSummaryResponse.java
@@ -12,6 +12,14 @@ import java.util.List;
 public class GraphSummaryResponse {
 
     private String period;
+    /**
+     * 로그 갯수 관련
+     */
+    private int totalCnt;
+
+    private int warnCnt;
+
+    private int dangerCnt;
 
     /**
      * SENSOR / EQUIP / WORKER 건수


### PR DESCRIPTION
## 📌 PR 제목
그래프 이상치 횟수 response 추가, Dto 수정

---

## ✨ 변경 사항
- 각 타입별 이상치 횟수는 전달이 되었으나 전체 이상치 횟수, 경고 전체 횟수, 위험 전체 횟수는 전달되지 않고 있었음
- 반환 DTO 속성 추가, 서비스 내 횟수 계산 로직 추가

---