### PR TITLE
fix | 테스트 | FRB-242 | 프론트 로직에 맞게 FCM 호출 로직 수정2 | 김우영

### DIFF
--- a/src/main/java/com/factoreal/backend/messaging/fcm/api/FCMController.java
+++ b/src/main/java/com/factoreal/backend/messaging/fcm/api/FCMController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/fcm")
@@ -37,38 +38,34 @@ public class FCMController {
 
     @Operation(summary = "작업자 안전(safety)알람 호출용", description = "상태 이상자를 도울사람에게 호출 전송")
     @PostMapping("/safety")
-    public ResponseEntity<Object> sendWorkerMessage(@RequestBody FCMSafetyRequest request) {
+    public FCMResponse sendWorkerMessage(@RequestBody FCMSafetyRequest request) {
 //        fcmService.sendMessage();
-        fcmService.sendWorkerSafety(request.getWorkerId(), request.getCareNeedWorkerId(), request.getMessage());
-        return ResponseEntity.ok().build();
+        return fcmService.sendWorkerSafety(request.getWorkerId(), request.getCareNeedWorkerId(), request.getMessage());
     }
 
     @Operation(summary = "공간 안전(safety)알람 호출용", description = "위험한 구역(zone)에 위치한 사람들에게 일괄 전송")
     @PostMapping("/zone")
-    public ResponseEntity<Object> sendZoneMessage(@RequestBody FCMZoneRequest request) {
+    public List<FCMResponse> sendZoneMessage(@RequestBody FCMZoneRequest request) {
 //        fcmService.sendMessage();
-        fcmService.sendZoneSafety(
+        return fcmService.sendZoneSafety(
                 request.getZoneId(),
                 request.getDangerLevel(),
                 TriggerType.MANUAL,
                 LocalDateTime.now(),
                 null
         );
-        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "설비 점검(maintain)알람 호출용", description = "설비와 점검자 ID를 받아 호출")
     @PostMapping("/equip")
-    public ResponseEntity<Object> sendEquipoMessage(@RequestBody FCMEquipRequest request) {
+    public FCMResponse sendEquipoMessage(@RequestBody FCMEquipRequest request) {
 //        fcmService.sendMessage();
-        fcmService.sendEquipMaintain(request.getWorkerId(), request.getEquipId(),request.getMessage());
-        return ResponseEntity.ok().build();
+        return fcmService.sendEquipMaintain(request.getWorkerId(), request.getEquipId(),request.getMessage());
     }
 
     @Operation(summary = "작업자 직접 호출용(메세지 직접 입력)",description = "작업자에게 직접 입력한 메세지를 전송")
     @PostMapping("/custom")
-    public ResponseEntity<Object> sendCustomMessage(@RequestBody FCMCustomRequest request){
-        fcmService.sendCustomMessage(request.getWorkerId(),request.getMessage());
-        return ResponseEntity.ok().build();
+    public FCMResponse sendCustomMessage(@RequestBody FCMCustomRequest request){
+        return fcmService.sendCustomMessage(request.getWorkerId(),request.getMessage());
     }
 }

--- a/src/main/java/com/factoreal/backend/messaging/fcm/dto/FCMResponse.java
+++ b/src/main/java/com/factoreal/backend/messaging/fcm/dto/FCMResponse.java
@@ -1,0 +1,16 @@
+package com.factoreal.backend.messaging.fcm.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Schema(title = "요청 성공 여부를 반환",description = "작업자Id, 작업자 명, 성공 여부, 실패 원인을 반환합니다.")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FCMResponse {
+    private String workerId;
+    private String workerName;
+    private boolean success;
+    private String errorDescription;
+}

--- a/src/test/java/com/factoreal/backend/messaging/fcm/application/FCMServiceTest.java
+++ b/src/test/java/com/factoreal/backend/messaging/fcm/application/FCMServiceTest.java
@@ -1,5 +1,6 @@
 package com.factoreal.backend.messaging.fcm.application;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.factoreal.backend.domain.abnormalLog.application.AbnormalLogRepoService;
@@ -20,6 +21,7 @@ import com.factoreal.backend.domain.zone.entity.Zone;
 import com.factoreal.backend.domain.zone.entity.ZoneHist;
 import com.factoreal.backend.global.exception.dto.BadRequestException;
 import com.factoreal.backend.global.exception.dto.NotFoundException;
+import com.factoreal.backend.messaging.fcm.dto.FCMResponse;
 import com.factoreal.backend.messaging.kafka.strategy.enums.SensorType;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import org.junit.jupiter.api.BeforeEach;
@@ -447,7 +449,12 @@ class FCMServiceTest {
             Worker NoTokenWorker = mockWorker;
             NoTokenWorker.setFcmToken(null);
             when(workerRepoService.findById(mockWorker.getWorkerId())).thenReturn(NoTokenWorker);
-            assertThrows(BadRequestException.class,()->fcmService.sendCustomMessage(mockWorker.getWorkerId(), "test Message"));
+            assertThat(fcmService.sendCustomMessage(mockWorker.getWorkerId(), "test Message")).isEqualTo(FCMResponse.builder()
+                    .workerId(mockWorker.getWorkerId())
+                .workerName(mockWorker.getName())
+                    .success(false)
+                    .errorDescription("❌ 작업자의 FCM 토큰이 없습니다.")
+                .build());
             verify(fcmPushService, never()).sendMessage(anyString(), anyString(), anyString());
             verify(notifyLogService, never()).saveNotifyLogFromFCM(anyString(), anyBoolean(), any(), any(), anyLong());
         }
@@ -458,7 +465,12 @@ class FCMServiceTest {
             Worker NoTokenWorker = mockWorker;
             NoTokenWorker.setFcmToken("");
             when(workerRepoService.findById(mockWorker.getWorkerId())).thenReturn(NoTokenWorker);
-            assertThrows(BadRequestException.class,()->fcmService.sendCustomMessage(mockWorker.getWorkerId(), "test Message"));
+            assertThat(fcmService.sendCustomMessage(mockWorker.getWorkerId(), "test Message")).isEqualTo(FCMResponse.builder()
+                .workerId(mockWorker.getWorkerId())
+                .workerName(mockWorker.getName())
+                .success(false)
+                .errorDescription("❌ 작업자의 FCM 토큰이 없습니다.")
+                .build());
             verify(fcmPushService, never()).sendMessage(anyString(), anyString(), anyString());
             verify(notifyLogService, never()).saveNotifyLogFromFCM(anyString(), anyBoolean(), any(), any(), anyLong());
         }


### PR DESCRIPTION
## 📌 PR 제목
프론트 로직에 맞게 FCM 호출 로직 수정2

---

## ✨ 변경 사항
- FCM 전송 여부 확인을 위한 FCMResponse 추가
- 실패 처리 이유를 같이 반환하도록 수정