### PR TITLE
fix | 테스트 | FRB-243 | 과거 조치된 점검일자 관련 수정 | 김우영

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/application/EquipMaintenanceService.java
@@ -62,7 +62,10 @@ public class EquipMaintenanceService {
         long daysUntilMaintenance = slackEquipAlarmService.getDaysUntilMaintenance(history.getAccidentDate());
 
         // 5. 응답 DTO 생성 및 반환
-        return LatestMaintenancePredictionResponse.fromEntity(equip, history, daysUntilMaintenance);
+        if (history.equals(latestUncheckedHistory.orElse(null))) { // 예상 점검일자에 대해 점검이 이루어 지지 않았다면 -> 점검 안됨.
+            return LatestMaintenancePredictionResponse.fromEntity(equip, history, daysUntilMaintenance,false);
+        } // 점검 기록이 있는 경우 -> 점검 됨.
+        return LatestMaintenancePredictionResponse.fromEntity(equip, history, daysUntilMaintenance,true);
     }
 
     /**

--- a/src/main/java/com/factoreal/backend/domain/equip/dto/response/LatestMaintenancePredictionResponse.java
+++ b/src/main/java/com/factoreal/backend/domain/equip/dto/response/LatestMaintenancePredictionResponse.java
@@ -23,8 +23,9 @@ public class LatestMaintenancePredictionResponse {
     private String zoneName;
     private LocalDate expectedMaintenanceDate;
     private Long daysUntilMaintenance;
+    private Boolean MaintenanceStatus;
 
-    public static LatestMaintenancePredictionResponse fromEntity(Equip equip, EquipHistory history, Long daysUntilMaintenance) {
+    public static LatestMaintenancePredictionResponse fromEntity(Equip equip, EquipHistory history, Long daysUntilMaintenance, Boolean MaintenanceStatus) {
         return LatestMaintenancePredictionResponse.builder()
             .equipId(equip.getEquipId())
             .equipName(equip.getEquipName())
@@ -32,6 +33,7 @@ public class LatestMaintenancePredictionResponse {
             .zoneName(equip.getZone().getZoneName())
             .expectedMaintenanceDate(history.getAccidentDate())
             .daysUntilMaintenance(daysUntilMaintenance)
+            .MaintenanceStatus(MaintenanceStatus)
             .build();
     }
 } 


### PR DESCRIPTION
## 📌 PR 제목
과거 조치된 점검일자 관련 수정

---

## ✨ 변경 사항
- ResponseDto에 점검 완료 여부 필드를 추가
- 점검되지 않은 예상 점검일자에 따라 점검완료여부를 분기하는 로직 추가

---