### PR TITLE
[fix] SQS consume 클라우드, 로컬 환경 분리 및 localtime 서울시간으로 변경

### DIFF
--- a/src/main/java/com/factoreal/backend/messaging/sqs/listener/S3EventSqsListener.java
+++ b/src/main/java/com/factoreal/backend/messaging/sqs/listener/S3EventSqsListener.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.ArrayList;
@@ -21,9 +22,14 @@ public class S3EventSqsListener {
     private final EquipPredictProcessor equipPredictProcessor;
     private final ObjectMapper objectMapper;
 
+    // application-*.yml 에서 설정된 큐 URL 을 주입
+    @Value("${aws.sqs.queue-url}")
+    private String queueUrl;
+
+
     // ① 큐 이름 또는 Queue URL을 value 작성
     //   (Queue URL 을 쓰면 renaming 걱정 없음)
-    @SqsListener(value = "https://sqs.ap-northeast-2.amazonaws.com/853660505909/S3NewJsonEventAlert")
+    @SqsListener("${aws.sqs.queue-url}")
     public void handleMessage(String rawMessage) {
 
         log.info("📥 SQS 메시지 수신: {}", rawMessage);

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -24,3 +24,8 @@ webhook:
 # 클러스터 내 Service 이름으로 덮어쓰기
 fastapi:
   base-url: ${FASTAPI_URL}
+
+aws:
+  sqs:
+    # 클라우드(프로덕션) 큐 URL
+    queue-url: ${SQS_QUEUE_URL}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,6 +21,9 @@ aws:
     listener:
       max-number-of-messages: 1 # 동시 처리 튜닝용
       wait-timeout : 5 # long-polling (초)
+    # 로컬 개발용 큐 URL
+    queue-url: ${SQS_QUEUE_URL_FOR_LOCAL}
+
 
 # 로컬에서 FastAPI가 돌고 있는 호스트:포트
 fastapi:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
   config:
     import: optional:file:.env[.properties]
 
+  jackson:
+    time-zone: Asia/Seoul
 
   # ===============================
   # JPA / Hibernate
@@ -15,6 +17,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: +09:00
     defer-datasource-initialization: false
 
   # ===============================


### PR DESCRIPTION
## 📌 PR 제목
[fix] SQS consume 클라우드, 로컬 환경 분리 및 localtime 서울시간으로 변경
<!-- ex: [feat] 로그인 기능 추가 -->

---

## ✨ 변경 사항
- SQS consume 클라우드, 로컬 환경 분리
   .application.yml, application-local.yml , application-cloud.yml
- java localtime UCT -> asia/seoul 로 변경

---

## 📸 스크린샷 
<img width="1321" alt="스크린샷 2025-06-13 오후 1 20 48" src="https://github.com/user-attachments/assets/64de383d-ff2d-4247-8ab4-83d1e7853bb5" />



---

## ✅ 체크리스트
- [x] 코드에 불필요한 부분은 없는가?
- [x] 기능이 정상 동작하는가?
- [x] 의존성은 문제가 없는가?
- [x] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 번호: https://facto-real.atlassian.net/browse/FRB-270

---

## 💬 추가 설명
- N/A 