### PR TITLE
[feat] Websocket 전송 부분 비동기 처리, 알림 전송 후 DB 저장하도록 로직 변경

### DIFF
--- a/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogService.java
+++ b/src/main/java/com/factoreal/backend/domain/abnormalLog/application/AbnormalLogService.java
@@ -55,7 +55,6 @@ public class AbnormalLogService {
      * @throws Exception
      */
     @Transactional(rollbackFor = Exception.class)
-
     public AbnormalLog saveAbnormalLogFromSensorKafkaDto(
             SensorKafkaDto sensorKafkaDto,
             SensorType sensorType,
@@ -202,6 +201,11 @@ public class AbnormalLogService {
         return abnormalLogRepoService.save(abnormalLog);
     }
 
+    @Transactional(rollbackFor = Exception.class)
+    public AbnormalLog saveAbnormalLog(AbnormalLog abnormalLog) {
+        return abnormalLogRepoService.save(abnormalLog);
+    }
+
     private Pageable getPageable(AbnormalPagingRequest abnormalPagingRequest) {
         return PageRequest.of(
                 abnormalPagingRequest.getPage(),
@@ -210,9 +214,10 @@ public class AbnormalLogService {
 
     /**
      * 설비 예측 기반 이상 로그 저장
-     * @param zone 공간 엔티티
-     * @param equip 설비 엔티티
-     * @param remainDays 계산된 잔존 수명(일)
+     *
+     * @param zone        공간 엔티티
+     * @param equip       설비 엔티티
+     * @param remainDays  계산된 잔존 수명(일)
      * @param dangerLevel 위험 레벨 (1 또는 2)
      */
     @Transactional

--- a/src/main/java/com/factoreal/backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/factoreal/backend/global/config/AsyncConfig.java
@@ -1,0 +1,41 @@
+package com.factoreal.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync   // <-- @Async를 사용할 수 있도록 활성화
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean(name = "websocketExecutor")
+    public Executor websocketExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);      // 동시에 실행할 기본 스레드 개수
+        executor.setMaxPoolSize(20);      // 최대 스레드 개수
+        executor.setQueueCapacity(100);   // 대기 큐 크기
+        executor.setThreadNamePrefix("ws-async-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public Executor getAsyncExecutor() {
+        // @Async가 별도 executor 이름을 지정하지 않으면 이게 디폴트로 사용됩니다.
+        return websocketExecutor();
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        // @Async 메서드 내 예외를 처리할 핸들러
+        return (throwable, method, params) -> {
+            // 로깅 또는 알림 등
+            System.err.printf("Async error in method %s: %s%n", method.getName(), throwable.getMessage());
+        };
+    }
+}

--- a/src/main/java/com/factoreal/backend/messaging/sender/WebSocketSender.java
+++ b/src/main/java/com/factoreal/backend/messaging/sender/WebSocketSender.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.scheduling.annotation.Async;
 
 @Component
 @RequiredArgsConstructor
@@ -21,6 +22,7 @@ public class WebSocketSender { // 실제로 프론트에 메시지를 전송하�
     /**
      * zone 별로 위험도 메시지를 WebSocket으로 전송
      */
+    @Async
     public void sendDangerLevel(String zoneId, String sensorType, int level) {
         ZoneDangerDto dangerDto = new ZoneDangerDto(zoneId, sensorType, level);
         messagingTemplate.convertAndSend("/topic/zone", dangerDto);
@@ -29,6 +31,7 @@ public class WebSocketSender { // 실제로 프론트에 메시지를 전송하�
     /**
      * Todo : 시스템 로그를 WebSocket으로 전송 -> restAPI 변경으로 삭제 예정
      */
+    @Async
     public void sendSystemLog(SystemLogDto logDto) {
         messagingTemplate.convertAndSend("/topic/system-log", logDto);
     }
@@ -36,6 +39,7 @@ public class WebSocketSender { // 실제로 프론트에 메시지를 전송하�
     /**
      * 알람 이벤트를 WebSocket으로 전송
      */
+    @Async
     public void sendDangerAlarm(AlarmEventResponse alarmEventResponse) {
         messagingTemplate.convertAndSend("/topic/alarm", alarmEventResponse);
     }
@@ -43,6 +47,7 @@ public class WebSocketSender { // 실제로 프론트에 메시지를 전송하�
     /**
      * 읽지 않은 알람수 전송
      */
+    @Async
     public void sendUnreadCount(long count) {
         messagingTemplate.convertAndSend("/topic/unread-count", count);
     }
@@ -50,6 +55,7 @@ public class WebSocketSender { // 실제로 프론트에 메시지를 전송하�
     /**
      * 제어 상태를 WebSocket으로 전송하고 FE에서 발송 여부를 확인할 수 있도록 함
      */
+    @Async
     public void sendControlStatus(ControlLog controlLog, Map<String, Boolean> deliveryStatus) {
         Map<String, Object> status = new HashMap<>();
         status.put("controlId", controlLog.getId());


### PR DESCRIPTION
## 📌 PR 제목
[feat] Websocket 전송 부분 비동기 처리, 알림 전송 후 DB 저장하도록 로직 변경

---

## ✨ 변경 사항
- Websocket 전송 부분 비동기 처리
- 알림 전송 후 DB 저장하도록 로직 변경

---

## 📸 스크린샷 (선택)
| 변경 전 | 변경 후 |
|--------|--------|
| <img width="1710" alt="Screenshot 2025-06-16 at 1 01 57 AM" src="https://github.com/user-attachments/assets/945f8c2e-8f7c-4a5b-a556-61a2a25dcacc" /> | <img width="1710" alt="Screenshot 2025-06-16 at 12 53 16 AM" src="https://github.com/user-attachments/assets/b13db19d-9b67-4c1d-99d3-5533c580d3d2" /> |
| <img width="1710" alt="Screenshot 2025-06-16 at 1 03 35 AM" src="https://github.com/user-attachments/assets/693f20be-75b5-4790-ae03-b06ad62c9e6c" /> | <img width="1710" alt="Screenshot 2025-06-16 at 12 54 31 AM" src="https://github.com/user-attachments/assets/6c4be71b-503e-475b-b257-e15227b35692" /> |

---

## ✅ 체크리스트
- [x] 코드에 불필요한 부분은 없는가?
- [x] 기능이 정상 동작하는가?
- [x] 의존성은 문제가 없는가?
- [x] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- https://facto-real.atlassian.net/browse/FRB-277

---

## 💬 추가 설명
- 
