### PR TITLE
[hotfix] 좌측 하단 알림과 우측 하단 알림 개수가 맞지 않는 오류 -> 한 곳에서 두 개의 웹소켓을 보내도록 변경

### DIFF
--- a/src/main/java/com/factoreal/backend/messaging/kafka/processor/SensorEventProcessor.java
+++ b/src/main/java/com/factoreal/backend/messaging/kafka/processor/SensorEventProcessor.java
@@ -158,9 +158,7 @@ public class SensorEventProcessor {
                     }
                 }
 
-                // 3. 읽지 않은 수 전송
-                Long count = abnormalLogRepoService.countByIsReadFalse();
-                webSocketSender.sendUnreadCount(count);
+
 
                 log.info("✅ 센서 이벤트 처리 완료: sensorId={}, zoneId={}, level={} ({} topic)",
                         sensorId, zoneId, dangerLevel, topic);

--- a/src/main/java/com/factoreal/backend/messaging/kafka/strategy/alarmList/WebSocketNotificationStrategy.java
+++ b/src/main/java/com/factoreal/backend/messaging/kafka/strategy/alarmList/WebSocketNotificationStrategy.java
@@ -1,5 +1,6 @@
 package com.factoreal.backend.messaging.kafka.strategy.alarmList;
 
+import com.factoreal.backend.domain.abnormalLog.application.AbnormalLogRepoService;
 import com.factoreal.backend.domain.notifyLog.dto.TriggerType;
 import com.factoreal.backend.domain.notifyLog.application.NotifyLogService;
 import com.factoreal.backend.messaging.sender.WebSocketSender;
@@ -19,6 +20,7 @@ public class WebSocketNotificationStrategy implements NotificationStrategy {
     // SimpMessagingTemplate은 WebSocketConfig.java에 EnableWebSocketMessageBroker 어노테이션에 의해 빈이 등록됨.
     private final WebSocketSender webSocketSender;
     private final NotifyLogService notifyLogService;
+    private final AbnormalLogRepoService abnormalLogRepoService;
     private static final String userId = "alarm-test";
 
     @Override
@@ -29,6 +31,8 @@ public class WebSocketNotificationStrategy implements NotificationStrategy {
         // 대시보드 전체에서 보여져야 하는 로직이면 고정 토픽으로 구분없이 보여주는 것도 좋을 듯 -> 고정 토픽을 사용중
         try {
             webSocketSender.sendDangerAlarm(alarmEventResponse);
+            Long count = abnormalLogRepoService.countByIsReadFalse();
+            webSocketSender.sendUnreadCount(count);
             notifyLogService.saveNotifyLogFromWebsocket(
                     "/topic/alarm",
                     Boolean.TRUE,


### PR DESCRIPTION
## 📌 PR 제목
좌측 하단 알림과 우측 하단 알림 개수가 맞지 않는 오류 수정

---

## ✨ 변경 사항
- 웹 소켓 보내고 나서 알림 개수도 전송하도록 변

---